### PR TITLE
Update devcontainer image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // See https://aka.ms/vscode-remote/devcontainer.json for format details.
 {
-	"image": "ludeeus/container:integration-debian",
+	"image": "ghcr.io/ludeeus/devcontainer/integration:stable",
 	"name": "Danfoss Ally integration development",
 	"context": "..",
 	"appPort": [


### PR DESCRIPTION
The image used in the devcontainer config was outdated and not working for me.

Looks like @ludeeus no longer publishes these images to Docker Hub, so I followed [their instructions](https://github.com/ludeeus/container/issues/263#issuecomment-1073179716) to update the image reference.

Now the devcontainer works as expected.