### PR TITLE
Fallback to temp_set for some thermostats plus new features

### DIFF
--- a/custom_components/danfoss_ally/__init__.py
+++ b/custom_components/danfoss_ally/__init__.py
@@ -1,4 +1,5 @@
 """Adds support for Danfoss Ally Gateway."""
+from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timedelta
@@ -26,7 +27,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-ALLY_COMPONENTS = ["binary_sensor", "climate", "sensor"]
+ALLY_COMPONENTS = ["binary_sensor", "climate", "sensor", "switch"]
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
 SCAN_INTERVAL = 15
@@ -219,6 +220,12 @@ class AllyConnector:
         ).total_seconds()
         if seconds_since_poll < 0.5:
             _LOGGER.warn("set_mode: Time since last poll %f sec.", seconds_since_poll)
+
+    def send_commands(self, device_id: str, listofcommands: list[Tuple[str, str]], postponeupdate: bool) -> None:
+        """Send list of commands for given device."""
+        if postponeupdate:
+            self._latest_write_time = datetime.utcnow()
+        self.ally.sendCommand(device_id, listofcommands)
 
     @property
     def authorized(self) -> bool:

--- a/custom_components/danfoss_ally/manifest.json
+++ b/custom_components/danfoss_ally/manifest.json
@@ -5,12 +5,11 @@
     "config_flow": true,
     "documentation": "https://github.com/MTrab/danfoss_ally/blob/master/README.md",
     "domain": "danfoss_ally",
-    "integration_type": "hub",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/MTrab/danfoss_ally/issues",
     "name": "Danfoss Ally",
     "requirements": [
-        "pydanfossally==0.0.27"
+        "pydanfossally==0.0.28"
     ],
     "version": "1.1.0"
 }

--- a/custom_components/danfoss_ally/sensor.py
+++ b/custom_components/danfoss_ally/sensor.py
@@ -29,7 +29,7 @@ class AllySensorType(IntEnum):
     TEMPERATURE = 0
     BATTERY = 1
     HUMIDITY = 2
-
+    FLOOR_TEMPERATURE = 3
 
 SENSORS = [
     SensorEntityDescription(
@@ -55,6 +55,14 @@ SENSORS = [
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         name="{} humidity",
+    ),
+    SensorEntityDescription(
+        key=AllySensorType.FLOOR_TEMPERATURE,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        entity_category=None,
+        native_unit_of_measurement=TEMP_CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        name="{} floor temperature",
     ),
 ]
 
@@ -114,7 +122,7 @@ class AllySensor(AllyDeviceEntity, SensorEntity):
         self._attr_native_value = None
         self._attr_extra_state_attributes = None
         self._attr_name = self.entity_description.name.format(name)
-        self._attr_unique_id = f"{self._type}_{device_id}_ally"
+        self._attr_unique_id = "{}_{}_ally".format(self._type.replace("_", " "), device_id)
 
     async def async_added_to_hass(self):
         """Register for sensor updates."""

--- a/custom_components/danfoss_ally/services.yaml
+++ b/custom_components/danfoss_ally/services.yaml
@@ -5,6 +5,10 @@ set_preset_temperature:
   description: Set target temperature of climate device.
   target:
     entity:
+      integration: danfoss_ally
+      domain: climate
+    device:
+      integration: danfoss_ally
       domain: climate
   fields:
     temperature:
@@ -34,3 +38,23 @@ set_preset_temperature:
               value: "holiday_sat"
             - label: "Holiday (Away)"
               value: "holiday"
+
+set_window_state_open:
+  name: Set window open state
+  description: Tell a radiator thermostat if window is open or closed (Icon does not have this feature). It takes a while for it to react.
+  target:
+    entity:
+      integration: danfoss_ally
+      domain: climate
+      model: "Danfoss Ally™ Radiator Thermostat"
+    device:
+      integration: danfoss_ally
+      domain: climate
+      model: "Danfoss Ally™ Radiator Thermostat"
+  fields:
+    window_open:
+      name: Window open
+      description: True = window open, false = closed
+      required: true
+      selector:
+        boolean:

--- a/custom_components/danfoss_ally/services.yaml
+++ b/custom_components/danfoss_ally/services.yaml
@@ -9,7 +9,6 @@ set_preset_temperature:
       domain: climate
     device:
       integration: danfoss_ally
-      domain: climate
   fields:
     temperature:
       name: Temperature

--- a/custom_components/danfoss_ally/services.yaml
+++ b/custom_components/danfoss_ally/services.yaml
@@ -46,10 +46,8 @@ set_window_state_open:
     entity:
       integration: danfoss_ally
       domain: climate
-      model: "Danfoss Ally™ Radiator Thermostat"
     device:
       integration: danfoss_ally
-      domain: climate
       model: "Danfoss Ally™ Radiator Thermostat"
   fields:
     window_open:

--- a/custom_components/danfoss_ally/switch.py
+++ b/custom_components/danfoss_ally/switch.py
@@ -1,0 +1,190 @@
+"""Support for Ally switched."""
+from __future__ import annotations
+
+import logging
+from enum import IntEnum
+from datetime import datetime, timedelta
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import EntityCategory
+
+from .const import DATA, DOMAIN, SIGNAL_ALLY_UPDATE_RECEIVED
+from .entity import AllyDeviceEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AllySwitchType(IntEnum):
+    """Supported sensor types."""
+
+#    DETECT_WINDOW_OPEN = 0
+
+SWITCHES = [
+    SwitchEntityDescription(
+        key="window_toggle",
+        entity_category=EntityCategory.CONFIG,
+        name="{} Open window detection",
+        device_class="switch",
+        icon = "mdi:window-open-variant",
+        entity_registry_enabled_default = False
+    ),
+    SwitchEntityDescription(
+        key="switch",
+        entity_category=EntityCategory.CONFIG,
+        name="{} Pre-Heat",
+        device_class="switch",
+        icon = "mdi:heat-wave",
+        entity_registry_enabled_default = False
+    )
+]
+
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+):
+    """Set up the Ally switch platform."""
+    _LOGGER.debug("Setting up Danfoss Ally switch entities")
+    ally = hass.data[DOMAIN][entry.entry_id][DATA]
+    entities = []
+
+    for device in ally.devices:
+        # if "window_toggle" in ally.devices[device]:
+        #     _LOGGER.debug("Found switch for window open detection: %s", ally.devices[device]["name"])
+        #     entities.extend(
+        #         [
+        #             AllyOpenWindowDetectionSwitch(
+        #                 ally,
+        #                 ally.devices[device]["name"],
+        #                 device,
+        #                 SWITCHES[AllySwitchType.DETECT_WINDOW_OPEN],
+        #                 ally.devices[device]["model"],
+        #             )
+        #         ]
+        #     )
+        if "model" in ally.devices[device] and ally.devices[device]["model"].lower() != "icon zigbee module":   # Do not show Pre-Hear for zigbee module
+            for switch in SWITCHES:
+                if switch.key in ["window_toggle", "switch"] and switch.key in ally.devices[device]:
+                    _LOGGER.debug("Found switch for setting: %s", ally.devices[device]["name"])
+                    entities.extend(
+                        [
+                            AllyGenericSwitch(
+                                ally,
+                                ally.devices[device]["name"],
+                                device,
+                                switch,
+                                ally.devices[device]["model"],
+                            )
+                        ]
+                    )
+
+    if entities:
+        async_add_entities(entities, True)
+
+
+
+
+class AllyBaseSwitch(AllyDeviceEntity, SwitchEntity):
+    """Representation of an Ally binary_sensor."""
+
+    def __init__(self, ally, name, device_id, description: SwitchEntityDescription, model, skipdelayafterwrite = 2):
+        """Initialize Ally switch."""
+        self.entity_description = description
+        self._ally = ally
+        self._device = ally.devices[device_id]
+        self._device_id = device_id
+        self._name = name
+        self._type = description.name.lower()
+        self._latest_write_time = None
+        self._skipdelayafterwrite = skipdelayafterwrite
+
+        super().__init__(name, device_id, self._type, model)
+
+        _LOGGER.debug("Device_id: %s --- Device: %s", self._device_id, self._device)
+        
+        self._attr_is_on = None
+        self._attr_extra_state_attributes = None
+        self._attr_name = self.entity_description.name.format(name)
+        self._attr_unique_id = "{}_{}_ally".format(self._type, device_id)
+
+    async def async_added_to_hass(self):
+        """Register for sensor updates."""
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_ALLY_UPDATE_RECEIVED,
+                self._async_update_callback,
+            )
+        )
+
+    @callback
+    def _async_update_callback(self):
+        """Update and write state."""
+
+        if self._latest_write_time is None or (datetime.utcnow() - self._latest_write_time).total_seconds() >= self._skipdelayafterwrite:
+            _LOGGER.debug("Loading new switch data for device %s", self._device_id)
+            self._device = self._ally.devices[self._device_id]
+            self._async_update_data()
+        else:
+            _LOGGER.debug("Skip update: %s, %s", self._device_id, self._ally_attr)
+        self.async_write_ha_state()
+
+    def _updateUI(self, new_state: bool):
+        self._latest_write_time = datetime.utcnow()
+        self._attr_is_on = new_state
+        self.async_write_ha_state()
+
+
+
+# class AllyOpenWindowDetectionSwitch(AllyBaseSwitch):
+
+#     def __init__(self, ally, name, device_id, description: SwitchEntityDescription, model):
+#         super().__init__(ally, name, device_id, description, model, 2)
+#         self._async_update_data()
+
+#     def turn_on(self, **kwargs):
+#         """Turn the switch on."""
+#         self._ally.send_commands(self._device_id, [("window_toggle", True)], False)
+#         super()._updateUI(True)
+
+#     def turn_off(self, **kwargs):
+#         """Turn the switch off."""
+#         self._ally.send_commands(self._device_id, [("window_toggle", False)], False)
+#         super()._updateUI(False)
+
+#     @callback
+#     def _async_update_data(self):
+#         """Load data."""
+#         self._attr_available = ("window_toggle" in self._device)
+#         if self._attr_available:
+#             self._attr_is_on = self._device["window_toggle"]
+
+
+class AllyGenericSwitch(AllyBaseSwitch):
+
+    def __init__(self, ally, name, device_id, description: SwitchEntityDescription, model):
+        self._ally_attr = description.key
+        super().__init__(ally, name, device_id, description, model, 2)
+        self._async_update_data()
+
+    def turn_on(self, **kwargs):
+        """Turn the switch on."""
+        self._ally.send_commands(self._device_id, [(self._ally_attr, True)], False)
+        super()._updateUI(True)
+
+    def turn_off(self, **kwargs):
+        """Turn the switch off."""
+        self._ally.send_commands(self._device_id, [(self._ally_attr, False)], False)
+        super()._updateUI(False)
+
+    @callback
+    def _async_update_data(self):
+        """Load data."""
+        self._attr_available = (self._ally_attr in self._device)
+        if self._attr_available:
+            self._attr_is_on = self._device[self._ally_attr]
+


### PR DESCRIPTION
Changes:

- Fallback to use `temp_set` when `manual_mode_fast`, `at_home_setting`, `leaving_home_setting`, `pause_setting` and `holiday_setting` are not available.
This is probably the case for some older radiator thermostats.
Issue #44 (apparently API refuses to switch mode, so this does not work)

- Re-added floor temperature sensor for Icon room sensors with floor sensor.
(it disappeared during the merge of the last version)

- Made the binary sensor "Connectivity" appear for all devices which have the information, and moved it to the Diagnostic section. Previously it was only available for the gateway and Zigbee module.
 
- Added two configuration switches: Pre-Heat on/off and Open-window detection on/off
These are disabled by default, to avoid accidental change in the UI.

- Added a binary sensor to indicate when it is pre-heating.
It is not the same as the configuration switch, but indicates when it seems to actually do pre-heating (some time ahead of switching scheduled to "home" setting)
 
- Added service call "Set window open state".
With this a Home Assistant automation can tell a radiator thermostat that a window is open or closed, before it detects it based on temperature drop.
Icon does not support this, as floor heating reacts much slower anyway. 

