### PR TITLE
Additional features

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,24 @@ This is a custom component for Home Assistant to integrate the Danfoss Ally and 
 
 First of all you need to go and create an api-key and secret
 
-* Navigate to https://developer.danfoss.com
-* Create Danfoss developer account and login *<u><b>NOTE:</b> Use the same email as used in the Danfoss Ally app for pairing your gateway</u>*
-* Go to https://developer.danfoss.com/my-apps and click "New App"
-* Give the app a name and description (naming and description is not of any importance as it's only for your use)
-* Make sure to enable Danfoss Ally API
-* Click create
-* Save your key and secret - these will be used when adding the integration
-* Go to Home Assistant > Settings > Integrations
-* Add Danfoss Ally integration *(If it doesn't show, try CTRL+F5 to force a refresh of the page)*
-* Enter API key and secret
+- Navigate to https://developer.danfoss.com
+- Create Danfoss developer account and login _<u><b>NOTE:</b> Use the same email as used in the Danfoss Ally app for pairing your gateway</u>_
+- Go to https://developer.danfoss.com/my-apps and click "New App"
+- Give the app a name and description (naming and description is not of any importance as it's only for your use)
+- Make sure to enable Danfoss Ally API
+- Click create
+- Save your key and secret - these will be used when adding the integration
+- Go to Home Assistant > Settings > Integrations
+- Add Danfoss Ally integration _(If it doesn't show, try CTRL+F5 to force a refresh of the page)_
+- Enter API key and secret
 
 Voila
 
+## Usage
+
+See: [Usage.md](Usage.md)
+
 ## Known issues
 
-* Inconsistency between API and app, devices are not updating correctly between API and app and sometimes the devices renders offline in the app - this is a Danfoss issue and not this integration
-* Floorheating modules (Icon) are not reporting the actual room temperature in the API - this is a Danfoss issue and not this integration
+- Inconsistency between API and app, devices are not updating correctly between API and app and sometimes the devices renders offline in the app - this is a Danfoss issue and not this integration
+- Floorheating modules (Icon) are not reporting the actual room temperature in the API - this is a Danfoss issue and not this integration

--- a/Usage.md
+++ b/Usage.md
@@ -1,0 +1,177 @@
+## Usage
+
+This integration has been made by enthusiasts with no insights to internal Danfoss documentation.
+We are only able to find the same public information as you are.
+Some good information can be found here though:
+
+- [Programming reference for Danfoss eTRV](https://assets.danfoss.com/documents/202524/AU417130778872en-000101.pdf)
+- [Zigbee specification for Danfoss eTRV](https://assets.danfoss.com/documents/193613/AM375549618098en-000102.pdf)
+
+The following is our understanding after the reading the linked documents and experimenting with the settings.
+We urge you to experiment with the features you would like to make use of.
+
+&nbsp;
+
+#### Banner control
+
+Banner control is a binary sensor that indicates if the setpoint is overridden locally from the thermostat.
+This is also reported in the Ally app as a "Temporary setpoint".
+
+&nbsp;
+
+#### Pre-heat
+
+- **Pre-Heat** switch located in the Configuration section can be used to turn on and off the pre-heat feature.
+  It is similar to the switch in the Ally mobile app.
+- **Pre-Heating** is a binary sensor that indicates it is it currently pre-heating.
+  With pre-heating it attempts to automatically determine how long before before a switch from `Away` to `Home` it should start to heat, to reach the target temperature when the scheduled time is reached.
+
+&nbsp;
+
+#### Temparature readings
+
+As the integration has evolved more and more temperature readings are becoming available, and it also differs depending on device type.
+
+- **Temperature** sensor: This is the temperature measured locally by the thermostat.
+  For a radiator it is measured by the thermostat, for Icon it is the one measured by the room 'thermostat' and for an Ally room sensor it is obviously the one measure by it.
+- **Floor temperature** sensor: In addition to the air temperature, some Danfoss Icon room 'thermostats' also measure the floor temperature by utilizing an infrared sensor. This sensor reports the measured value.
+  The sensor only appears when the room 'thermostat' has the infrared sensor.
+- **External sensor temperature**: This is the temperature measurement that is being sent to a radiator thermostat, typically by an Ally room sensor. However, this external temperature can also be sent through the API (see service call).
+- **Climate control current temparature**: This value most often shows the local temperature. However, for a radiator thermostat it can also show the external temperature here. It depends what mode it is in:
+  - `Room Sensor Mode` (Covered radiators): Reports the external sensor temparature as current measurement
+    (This is new from version 1.2.0. This is similar to the Ally mobile app)
+  - `Auto Offset Mode` (Exposed radiators / uncovered): Reports the local temperature as current measurement
+- **Radiator covered** switch: This is a switch that can be used to control mode. Basically it determines how it uses an external temperature measurement.
+  - When covered it is in `Room Sensor Mode`: Here it uses the external temperature solely and bases valve regulation on it.
+  - When not covered it is in `Auto Offset Mode`: Here the external temperature is used to calculate an offset up to ± 2.5°C. Then it uses this offset and its local temperature while regulating the valve.
+    (we are not currently able to read the offset from the API)
+- Service call **Danfoss Ally: Set external temperature**: This service call can send an external temperature to a radiator thermostat, similar to an Ally room sensor. If the radiator is placed so it cannot reliably determine temperature in the room, or you have another sensor placed better, you can now use it instead of an Ally room sensor. It means of course it is not a one-off call, it needs to be activated whenever the temperature changes.
+  Example automation:
+
+      alias: Set radiator external temperature
+      description: ""
+      trigger:
+        - platform: state
+          entity_id:
+            - sensor.some_temperature_entity
+          from: null
+        - platform: time_pattern
+          minutes: /30
+      condition: []
+      action:
+        - service: danfoss_ally.set_external_temperature
+          data:
+            temperature: "{{ states('sensor.some_temperature_entity') }}"
+          target:
+            entity_id: climate.danfoss_allytm_radiator_thermostat
+      mode: single
+
+  It calls the service whenever the source entity changes, but note that it also does every 30 minutes.
+  When in Room Sensor Mode it must be called at least every 30 minutes. After 35 minutes without an update it goes back to using the local temperature.
+  When in Auto Offset Mode it must instead be called at least every 3 hours.
+  To preserve battery it is also recommended not to set value more frequent than every 5 minutes (30 in offset mode). The integration will automatically avoid too frequent calls with the same value.
+
+  To actively disable the feature and go back to local measurement, send temperature -80°C or any non-numeric value.
+
+  Use this feature to try out how an external sensor temperature would work. Realibility-wise do not expect it to be as reliable as an Ally room sensor.
+  Just consider the communication path. The ally room sensor is using Zigbee like the thermostat, meaning that in theory it can send readings directly (it is unknown if it actually does, or if it goes through the gateway). Meaning not being dependent of the Ally gateway, power, internet or the Danfoss cloud, at least for a while. If the external temperature is set by Home Assistant, it is dependent of all this, including HA, your other sensor and possibly another Zigbee network.
+  However it does work and you can usually set an an external temperature this way. Just also consider what happens if/when disrupted.
+  Note: Currently we are not able to see if/when it switches back to using its own temperature reading.
+
+&nbsp;
+
+#### Set target temperature
+
+To set target temperature for a thermostat there is a function named "Set preset temperature". This is exposed both as a service call and as a device action in automations.
+In both cases there are two arguments:
+
+- Temperature (required)
+- Preset mode (optional)
+  Preset mode determines which mode the target temperature is set for, ex. `Manual`, `Home`, `Away` etc. If not specified, target temperature will be set for the current preset mode.
+
+&nbsp;
+
+#### Set HVAC mode
+
+With this device action we can switch between `heat` and `auto`.
+Basically it is translated to preset modes `manual` and `home` respectively.
+
+&nbsp;
+
+#### Set preset mode
+
+With this device action we can switch switch to preset modes: `Home`, `Away`, `Manual`, `Pause`, `Holiday (Home)` & `Holiday (Away)`
+
+&nbsp;
+
+#### Open Window _(\*1)_
+
+This feature turns off heat to a radiator if an open window is detected. It has the ability to detect this itself, but we can also tell it that a window is open.
+However this feature is disabled in `Room Sensor Mode` (covered)
+
+- **Open window detection**: is a switch that enables and disables the open window feature.
+  It is similar to the switch in the Ally app.
+- **Open window**: A windows is open and it will reduce heat.
+- Service call **Danfoss Ally: Set window open state**: By calling this service we can tell it if a window is currently open or not.
+
+&nbsp;
+
+#### Mounting mode _(\*1)_
+
+In the Diagnostic sections radiators will have two binary sensors:
+
+- **Mounting mode control**: This indicates if the thermostat is in mounting mode, like when you initially mounted it on the valve. You can also make to go into this mode afterwards by holding the button for one second, an M is written in the display and preasure on the valve is released (opens valve fully).
+  The API allows for this to be set, but to avoid costly mistakes this integration shows it as read only. There is little reason to set it in mounting mode from Home Assistant anyway.
+- **Mounting mode active**: This indicates if it has detected that it is mounted (probably detected some resistance to push the valve).
+
+&nbsp;
+
+#### Valve opening _(\*1)_
+
+In the Diagnostic sections radiators will have a sensor with a percentage value saying how much open the valve is. 0% means it is closed, 100% that it is fully open. The thermostat regulates this valve in attempt to reach the target temperature.
+This value is read-only, we can only use it to get some insights.
+
+&nbsp;
+
+#### Load balance _(\*1)_
+
+In rooms with multiple radiadors this feature can be used. It lets Ally determine how much load should be delivered by each radiator (see Programming reference for a more details).
+We have two sensors and a switch made available:
+
+- **Load room mean**: A value calculated by the gateway and sent to all radiators in the room.
+- **Load estimate**: The load on each radiator.
+- **Load balance** switch: An enable/disable switch. Indicates if you want to use the feature or not.
+
+&nbsp;
+
+#### Heat available _(\*1)_
+
+In this section we have two binary sensors and a switch:
+
+- **Boiler relay**: Likely a signal to a gas boiler or similar to indicate heat is needed.
+- **Heat supply request**: Likely similar to Boiler relay. The difference may be explained in the Programming reference, section 2.6.
+- **Heat available** switch: A signal to the thermostat. Probably indicating if water is heated sufficuently. Default on.
+
+&nbsp;
+
+#### Adaptation run _(\*1)_
+
+In order for the thermostat to run optimally it regularly performs an adaptation run to estimate the Valve characteristic.
+
+- **Adaptation run status**: Indicates if it is currently performing an adaptation run.
+- **Adaptation run valve characteristic found**: Indicates that adaptation run was successful, and it determined the valve characteristic.
+
+&nbsp;
+
+#### Heating Control Scaling _(\*1)_
+
+With this control option you can set how aggressive the control algorithm controls the valve opening.
+Possible values:
+
+- Quick (5min)
+- Moderate (30min)
+- Slow (80min)
+
+&nbsp;
+
+_(\*1): Radiator only_

--- a/custom_components/danfoss_ally/binary_sensor.py
+++ b/custom_components/danfoss_ally/binary_sensor.py
@@ -101,6 +101,97 @@ async def async_setup_entry(
                     )
                 ]
             )
+        if "factory_reset" in ally.devices[device] and ally.devices[device][
+            "model"
+        ] in ["Danfoss Ally™ Radiator Thermostat"]:
+            _LOGGER.debug(
+                "Found mounting mode control detector for %s",
+                ally.devices[device]["name"],
+            )
+            entities.extend(
+                [
+                    AllyBinarySensor(
+                        ally,
+                        ally.devices[device]["name"],
+                        device,
+                        "mounting mode control",
+                        ally.devices[device]["model"],
+                    )
+                ]
+            )
+        if "mounting_mode_active" in ally.devices[device]:
+            _LOGGER.debug(
+                "Found mounting mode active detector for %s",
+                ally.devices[device]["name"],
+            )
+            entities.extend(
+                [
+                    AllyBinarySensor(
+                        ally,
+                        ally.devices[device]["name"],
+                        device,
+                        "mounting mode active",
+                        ally.devices[device]["model"],
+                    )
+                ]
+            )
+        if "heat_supply_request" in ally.devices[device]:
+            _LOGGER.debug(
+                "Found heat_supply_request detector for %s",
+                ally.devices[device]["name"],
+            )
+            entities.extend(
+                [
+                    AllyBinarySensor(
+                        ally,
+                        ally.devices[device]["name"],
+                        device,
+                        "heat supply request",
+                        ally.devices[device]["model"],
+                    )
+                ]
+            )
+        if "boiler_relay" in ally.devices[device]:
+            _LOGGER.debug(
+                "Found boiler relay_detector for %s", ally.devices[device]["name"]
+            )
+            entities.extend(
+                [
+                    AllyBinarySensor(
+                        ally,
+                        ally.devices[device]["name"],
+                        device,
+                        "boiler relay",
+                        ally.devices[device]["model"],
+                    )
+                ]
+            )
+        if "adaptation_runstatus" in ally.devices[device]:
+            _LOGGER.debug(
+                "Found adaptation_runstatus for %s", ally.devices[device]["name"]
+            )
+            entities.extend(
+                [
+                    AllyBinarySensor(
+                        ally,
+                        ally.devices[device]["name"],
+                        device,
+                        "adaptation run status",
+                        ally.devices[device]["model"],
+                    )
+                ]
+            )
+            entities.extend(
+                [
+                    AllyBinarySensor(
+                        ally,
+                        ally.devices[device]["name"],
+                        device,
+                        "adaptation run valve characteristic found",
+                        ally.devices[device]["model"],
+                    )
+                ]
+            )
 
     if entities:
         async_add_entities(entities, True)
@@ -144,6 +235,50 @@ class AllyBinarySensor(AllyDeviceEntity, BinarySensorEntity):
                 and "switch" in self._device
                 and bool(self._device["switch"])
             )
+        elif self._type == "mounting mode control":
+            self._state = self._device["factory_reset"]
+            self.entity_description = BinarySensorEntityDescription(
+                key=1,
+                entity_category=EntityCategory.DIAGNOSTIC,
+                icon="mdi:alpha-m",
+                entity_registry_enabled_default=False,
+            )
+        elif self._type == "mounting mode active":
+            self._state = self._device["mounting_mode_active"]
+            self.entity_description = BinarySensorEntityDescription(
+                key=2,
+                entity_category=EntityCategory.DIAGNOSTIC,
+                icon="mdi:thermostat",
+                entity_registry_enabled_default=False,
+            )
+        elif self._type == "heat supply request":
+            self._state = self._device["heat_supply_request"]
+            self.entity_description = BinarySensorEntityDescription(
+                key=3, icon="mdi:water-boiler", entity_registry_enabled_default=False
+            )
+        elif self._type == "boiler relay":
+            self._state = self._device["boiler_relay"]
+            self.entity_description = BinarySensorEntityDescription(
+                key=4, icon="mdi:gas-burner", entity_registry_enabled_default=False
+            )
+        elif self._type == "adaptation run status":
+            self._state = bool(int(self._device["adaptation_runstatus"]) & 0x01)
+            self.entity_description = BinarySensorEntityDescription(
+                key=5,
+                entity_category=EntityCategory.DIAGNOSTIC,
+                icon="mdi:progress-clock",
+                entity_registry_enabled_default=False,
+            )
+        elif self._type == "adaptation run valve characteristic found":
+            self._state = bool(
+                int(self._device["adaptation_runstatus"]) & 0x02
+            ) and not bool(int(self._device["adaptation_runstatus"]) & 0x04)
+            self.entity_description = BinarySensorEntityDescription(
+                key=6,
+                entity_category=EntityCategory.DIAGNOSTIC,
+                icon="mdi:progress-check",
+                entity_registry_enabled_default=False,
+            )
 
     async def async_added_to_hass(self):
         """Register for sensor updates."""
@@ -186,6 +321,8 @@ class AllyBinarySensor(AllyDeviceEntity, BinarySensorEntity):
             return BinarySensorDeviceClass.TAMPER
         elif self._type == "Pre-Heating":
             return BinarySensorDeviceClass.HEAT
+        elif self._type == "adaptation run status":
+            return BinarySensorDeviceClass.RUNNING
         return None
 
     @callback
@@ -216,3 +353,17 @@ class AllyBinarySensor(AllyDeviceEntity, BinarySensorEntity):
                 and "switch" in self._device
                 and bool(self._device["switch"])
             )
+        elif self._type == "mounting mode control":
+            self._state = self._device["factory_reset"]
+        elif self._type == "mounting mode active":
+            self._state = self._device["mounting_mode_active"]
+        elif self._type == "heat supply request":
+            self._state = self._device["heat_supply_request"]
+        elif self._type == "boiler relay":
+            self._state = self._device["boiler_relay"]
+        elif self._type == "adaptation run status":
+            self._state = bool(int(self._device["adaptation_runstatus"]) & 0x01)
+        elif self._type == "adaptation run valve characteristic found":
+            self._state = bool(
+                int(self._device["adaptation_runstatus"]) & 0x02
+            ) and not bool(int(self._device["adaptation_runstatus"]) & 0x04)

--- a/custom_components/danfoss_ally/manifest.json
+++ b/custom_components/danfoss_ally/manifest.json
@@ -1,13 +1,14 @@
 {
+    "domain": "danfoss_ally",
+    "name": "Danfoss Ally",
     "codeowners": [
         "@MTrab"
     ],
     "config_flow": true,
     "documentation": "https://github.com/MTrab/danfoss_ally/blob/master/README.md",
-    "domain": "danfoss_ally",
+    "integration_type": "hub",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/MTrab/danfoss_ally/issues",
-    "name": "Danfoss Ally",
     "requirements": [
         "pydanfossally==0.0.28"
     ],

--- a/custom_components/danfoss_ally/pydanfossally
+++ b/custom_components/danfoss_ally/pydanfossally
@@ -1,0 +1,1 @@
+/workspaces/pydanfossally/pydanfossally/

--- a/custom_components/danfoss_ally/select.py
+++ b/custom_components/danfoss_ally/select.py
@@ -1,0 +1,225 @@
+"""Support for Ally select."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from enum import IntEnum
+
+from homeassistant.components.select import (
+    SelectEntity,
+    SelectEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import EntityCategory
+
+from .const import DATA, DOMAIN, SIGNAL_ALLY_UPDATE_RECEIVED
+from .entity import AllyDeviceEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AllySelectType(IntEnum):
+    """Supported sensor types."""
+
+
+options_hcs = {"Quick (5min)": 1, "Moderate (30min)": 5, "Slow (80min)": 10}
+
+SELECTS = [
+    SelectEntityDescription(
+        key="ctrl_alg",
+        entity_category=EntityCategory.CONFIG,
+        name="{} Heating Control Scaling",
+        device_class=None,
+        options=list(options_hcs.keys()),
+        icon="mdi:car-traction-control",
+        entity_registry_enabled_default=False,
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+):
+    """Set up the Ally select platform."""
+    _LOGGER.debug("Setting up Danfoss Ally select entities")
+    ally = hass.data[DOMAIN][entry.entry_id][DATA]
+    entities = []
+
+    for device in ally.devices:
+        for sel in SELECTS:
+            if (
+                sel.key
+                in [
+                    "ctrl_alg",
+                ]
+                and sel.key in ally.devices[device]
+            ):
+                _LOGGER.debug(
+                    "Found select for setting: %s", ally.devices[device]["name"]
+                )
+                entities.extend(
+                    [
+                        AllyHcsSelect(
+                            ally,
+                            ally.devices[device]["name"],
+                            device,
+                            sel,
+                            ally.devices[device]["model"],
+                            options_hcs,
+                        )
+                    ]
+                )
+
+    if entities:
+        async_add_entities(entities, True)
+
+
+class AllyBaseSelect(AllyDeviceEntity, SelectEntity):
+    """Base class of select"""
+
+    def __init__(
+        self,
+        ally,
+        name,
+        device_id,
+        description: SelectEntityDescription,
+        model,
+        options,
+        skipdelayafterwrite=2,
+    ):
+        """Initialize Ally select."""
+        self.entity_description = description
+        self._ally = ally
+        self._device = ally.devices[device_id]
+        self._device_id = device_id
+        self._name = name
+        self._options = options
+        self._type = description.name.lower()
+        self._latest_write_time = None
+        self._skipdelayafterwrite = skipdelayafterwrite
+
+        super().__init__(name, device_id, self._type, model)
+
+        _LOGGER.debug("Device_id: %s --- Device: %s", self._device_id, self._device)
+
+        self._attr_current_option = None
+        self._attr_extra_state_attributes = None
+        self._attr_name = self.entity_description.name.format(name)
+        self._attr_unique_id = "{}_{}_ally".format(self._type, device_id)
+
+    async def async_added_to_hass(self):
+        """Register for sensor updates."""
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_ALLY_UPDATE_RECEIVED,
+                self._async_update_callback,
+            )
+        )
+
+    @callback
+    def _async_update_callback(self):
+        """Update and write state."""
+
+        if (
+            self._latest_write_time is None
+            or (datetime.utcnow() - self._latest_write_time).total_seconds()
+            >= self._skipdelayafterwrite
+        ):
+            _LOGGER.debug("Loading new select data for device %s", self._device_id)
+            self._device = self._ally.devices[self._device_id]
+            self._async_update_data()
+        else:
+            _LOGGER.debug("Skip update: %s, %s", self._device_id, self._type)
+        self.async_write_ha_state()
+
+    def update_ui(self, option: str):
+        """Update UI."""
+        self._latest_write_time = datetime.utcnow()
+        self._attr_current_option = option
+        self.async_write_ha_state()
+
+    @callback
+    def _async_update_data(self):
+        """Virtual function. Override in derived class to define update method."""
+        raise NotImplementedError()
+
+
+# class AllyGenericSelect(AllyBaseSelect):
+#     """Generic select: description.key must be the name of the ally attribute."""
+
+#     def __init__(
+#         self,
+#         ally,
+#         name,
+#         device_id,
+#         description: SelectEntityDescription,
+#         model,
+#         options,
+#     ):
+#         """Initialize Ally generic select."""
+#         self._ally_attr = description.key
+#         super().__init__(ally, name, device_id, description, model, options, 2)
+#         self._async_update_data()
+
+#     def select_option(self, option: str) -> None:
+#         """Set selected option."""
+#         value = self._options[option]
+#         self._ally.send_commands(self._device_id, [(self._ally_attr, value)], False)
+#         super().update_ui(option)
+
+#     @callback
+#     def _async_update_data(self):
+#         """Load data."""
+#         self._attr_available = self._ally_attr in self._device
+#         if self._attr_available:
+#             value = self._device[self._ally_attr]
+#             option = None
+#             for item in self._options:
+#                 if value == self._options[item]:
+#                     option = item
+#             self._attr_current_option = option
+
+
+class AllyHcsSelect(AllyBaseSelect):
+    """Select for Heating Control Scaling (lower 4 bits only): description.key must be the name of the ally attribute."""
+
+    def __init__(
+        self,
+        ally,
+        name,
+        device_id,
+        description: SelectEntityDescription,
+        model,
+        options,
+    ):
+        """Initialize Ally generic select."""
+        self._ally_attr = description.key
+        super().__init__(ally, name, device_id, description, model, options, 2)
+        self._async_update_data()
+
+    def select_option(self, option: str) -> None:
+        """Set selected option, lower 4 bits only, keep other bits."""
+
+        value = self._options[option]
+        other_bits = int(self._device[self._ally_attr]) & 0xF0  # It is an uint8
+        value = (int(value) & 0x0F) | other_bits
+
+        self._ally.send_commands(self._device_id, [(self._ally_attr, value)], False)
+        super().update_ui(option)
+
+    @callback
+    def _async_update_data(self):
+        """Load data."""
+        self._attr_available = self._ally_attr in self._device
+        if self._attr_available:
+
+            value = int(self._device[self._ally_attr]) & 0x0F
+            option = None
+            for item in self._options:
+                if value >= self._options[item]:
+                    option = item
+            self._attr_current_option = option

--- a/custom_components/danfoss_ally/services.yaml
+++ b/custom_components/danfoss_ally/services.yaml
@@ -55,3 +55,28 @@ set_window_state_open:
       required: true
       selector:
         boolean:
+
+set_external_temperature:
+  name: Set external temperature
+  description: Sends an external temperature measurement to a radiator thermostat. It is similar to what an Ally Room Sensor does.
+  target:
+    entity:
+      integration: danfoss_ally
+      domain: climate
+    device:
+      integration: danfoss_ally
+      model: "Danfoss Ally™ Radiator Thermostat"
+  fields:
+    temperature:
+      name: Temperature
+      description: Temperature to send to thermostat. If not set or unknown will disable the external temperature.
+      required: false
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 0.1
+          mode: box
+          unit_of_measurement: "ºC"
+
+


### PR DESCRIPTION
This PR is dependent on  MTrab/pydanfossally#10 for all features to be available (manifest.json requirements needs to be updated to the new pydanfossally version).
It is assumed this PR gets version 1.2.0 (it is mentioned in Usage.md).

Generally it adds many features for radiators, which do not exist or are not exposed for Icon.  
There are quite a few new sensors to provide extra insights, but also a few control options.

Changes:
- Many minor code adjustments to avoid pylint warnings.
- Current temperature on climate control now shows the external sensor temparature when in Room Sensor Mode.  
  This is similar to the Ally mobile app.

New:
- A **Usage.md** file providing a short description of each feature.
- External temperature sensor
- "Radiator covered" switch to select mode for external temperature
- Service call "Set external temperature" to send an external temperature (alternative to room sensor).  
  Solves #1 
- Valve opening sensor to show how much the valve is opened.
- Two binary-sensors to show Mounting mode  
  (One could be a switch, but I decides to keep it read-only)
- Load balance insights and enable/disable switch
- Heat available indicators and switch  
  May solve #35 
- Adaptation run binary-sensors
- Heating Control Scaling to control how aggressive it regulates

Except for the Valve opening sensor, all new sensors and switches are disabled by default to avoid confusion and changing anything inadvertently.

