### PR TITLE
Bump pydanfossally to v0.0.30

### DIFF
--- a/custom_components/danfoss_ally/manifest.json
+++ b/custom_components/danfoss_ally/manifest.json
@@ -10,7 +10,7 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/MTrab/danfoss_ally/issues",
     "requirements": [
-        "pydanfossally==0.0.29"
+        "pydanfossally==0.0.30"
     ],
     "version": "1.2.0"
 }


### PR DESCRIPTION
Depends on https://github.com/MTrab/pydanfossally/pull/11 to fix setting preset mode having effect on the actual valve opening of TRVs.

Would be nice with a new release (perhaps just v1.3.0) after this is merged. Thanks in advance 🙂 