### PR TITLE
Add automation blueprint for external temperature updates

### DIFF
--- a/blueprints/automations/danfoss_ally/set_external_temperature.yaml
+++ b/blueprints/automations/danfoss_ally/set_external_temperature.yaml
@@ -1,0 +1,44 @@
+blueprint:
+  name: Danfoss Ally™ External Temperature
+  description: Link one or more external temperature sensors to one or more Danfoss Ally thermostats
+  domain: automation
+  author: Thomas Barnekov
+  input:
+    temperature_sensors:
+      name: Temperature sensor
+      description: "This sensor will be used to measure the temperature"
+      selector:
+        entity:
+          multiple: true
+          filter:
+            - domain: sensor
+              device_class: temperature
+    target_thermostats:
+      name: Ally thermostat
+      description: "The selected thermostat(s) will be updated using the external temperature measured by the sensor(s) selected above"
+      selector:
+        target:
+          entity:
+            - integration: danfoss_ally
+              domain: climate
+          device:
+            - integration: danfoss_ally
+              model: "Danfoss Ally™ Radiator Thermostat"
+
+variables:
+  temperature_entities: !input temperature_sensors
+
+trigger:
+  - platform: state
+    entity_id: !input temperature_sensors
+
+action:
+  - alias: Set external temperature
+    service: danfoss_ally.set_external_temperature
+    data:
+      temperature: >
+        {% set sensors = expand(temperature_entities) | map(attribute='state') | map('float', none) | reject('eq', none) | list %}
+        {{ ((sensors | sum) / (sensors | count)) | round(2) }}
+    target: !input target_thermostats
+
+      


### PR DESCRIPTION
I created an automation blueprint to make it easier to update the external temperature property of the Ally thermostats.

The blueprint supports selecting multiple temperature sensors and multiple thermostats. Temperature sensor values are averaged before being sent to the selected thermostat(s). You'll need to add an automation for every room that has one or more external temperature sensor and one or more thermostats.

The blueprint expects temperature sensor values to be in Celsius. If anyone knows how to support Fahrenheit please let me know.