### PR TITLE
Update sensor_avg_temp when setting external temperature

### DIFF
--- a/custom_components/danfoss_ally/climate.py
+++ b/custom_components/danfoss_ally/climate.py
@@ -366,6 +366,7 @@ class AllyClimate(AllyDeviceEntity, ClimateEntity):
                 self._device_id,
                 [
                     ("ext_measured_rs", temp_100),
+                    ("sensor_avg_temp", temp_10),
                 ],
                 False,
             )


### PR DESCRIPTION
External temperature is read from "sensor_avg_temp" but the integration only sets "ext_measured_rs" when updating the external temperature. This results in the Ally thermostats always showing the same temperature regardless of the actually measured temp.

I'm suspect that the Ally gateway updates "sensor_avg_temp" if you have one or more Ally Room Sensors, but if you don't then it won't be updated.

The PR just updates "sensor_avg_temp" every time "ext_measured_rs" is updated.