### PR TITLE
Fix hassfest validation for Danfoss Ally services

### DIFF
--- a/custom_components/danfoss_ally/services.yaml
+++ b/custom_components/danfoss_ally/services.yaml
@@ -7,8 +7,6 @@ set_preset_temperature:
     entity:
       integration: danfoss_ally
       domain: climate
-    device:
-      integration: danfoss_ally
   fields:
     temperature:
       name: Temperature
@@ -45,9 +43,6 @@ set_window_state_open:
     entity:
       integration: danfoss_ally
       domain: climate
-    device:
-      integration: danfoss_ally
-      model: "Danfoss Ally™ Radiator Thermostat"
   fields:
     window_open:
       name: Window open
@@ -63,9 +58,6 @@ set_external_temperature:
     entity:
       integration: danfoss_ally
       domain: climate
-    device:
-      integration: danfoss_ally
-      model: "Danfoss Ally™ Radiator Thermostat"
   fields:
     temperature:
       name: Temperature
@@ -78,5 +70,4 @@ set_external_temperature:
           step: 0.1
           mode: box
           unit_of_measurement: "ºC"
-
 

--- a/custom_components/danfoss_ally/strings.json
+++ b/custom_components/danfoss_ally/strings.json
@@ -1,6 +1,5 @@
 {
     "config": {
-      "title": "Danfoss Ally",
       "abort": {
         "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
       },


### PR DESCRIPTION
## Summary
- remove unsupported device filters from service targets in `services.yaml`
- remove deprecated `config.title` from `strings.json`
- make `hassfest` pass again for the Danfoss Ally integration

## Test strategy
- Ran `docker run --rm -v /development/github/homeassistant/danfoss_ally:/github/workspace ghcr.io/home-assistant/hassfest`
- Verified `Invalid integrations: 0`

## Known limitations
- This PR only fixes the current `hassfest` validation failure and translation warning
- It does not add test fixtures in this round, per request
- The release workflow still appears to reference `landroid_cloud`, which is separate from this fix

## Required configuration changes
- None
