### PR TITLE
Fix release manifest newline handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
 
           with manifest_path.open("w", encoding="utf-8") as manifest_file:
               json.dump(ordered_manifest, manifest_file, indent=4)
-              manifest_file.write("\\n")
+              manifest_file.write("\n")
           PY
 
       - name: Commit manifest update


### PR DESCRIPTION
## Summary
- write an actual newline to `manifest.json` during the release workflow
- avoid writing the literal characters `\n` into the manifest file

## Test strategy
- reviewed the workflow change locally
- no runtime code paths changed; validation will rely on GitHub Actions checks

## Known limitations
- workflow behavior is only fully exercised when the release workflow runs in GitHub Actions

## Configuration changes
- none
