### PR TITLE
Bump pydanfossally to 1.0.1

### DIFF
--- a/custom_components/danfoss_ally/manifest.json
+++ b/custom_components/danfoss_ally/manifest.json
@@ -13,7 +13,7 @@
         "pydanfossally"
     ],
     "requirements": [
-        "pydanfossally@git+https://github.com/MTrab/pydanfossally.git@master"
+        "pydanfossally==1.0.1"
     ],
     "version": "1.3.7"
 }


### PR DESCRIPTION
## Summary
- switch the integration requirement from the git reference to the published `pydanfossally==1.0.1`

## Test strategy
- no local tests run; this change only updates the manifest dependency pin
- rely on CI validation for the integration package

## Known limitations
- successful installation depends on `pydanfossally` version `1.0.1` being available from PyPI mirrors used by the environment

## Configuration changes
- none
