### PR TITLE
Document Danfoss API analytics path for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ See: [Usage.md](Usage.md)
 
 - Inconsistency between API and app, devices are not updating correctly between API and app and sometimes the devices renders offline in the app - this is a Danfoss issue and not this integration
 - Danfoss Ally cloud/API synchronization is not real-time. Changes made from Home Assistant, the Danfoss app, or directly on a device may take a few minutes before they are reflected consistently across the API and the physical device state.
+- For debugging API performance or timeout issues, you can inspect API analytics in `Danfoss Developer Portal > Apps > [app name] > Analytics`, next to `Credentials`.
 
 
 


### PR DESCRIPTION
## Summary
- add a short README note about where to find API analytics in the Danfoss Developer Portal
- place the note in the troubleshooting context instead of setup

## Test strategy
- documentation-only change

## Known limitations
- none

## Configuration changes
- none
