### PR TITLE
Bump pydanfossally to 1.0.3

### DIFF
--- a/custom_components/danfoss_ally/manifest.json
+++ b/custom_components/danfoss_ally/manifest.json
@@ -13,7 +13,7 @@
         "pydanfossally"
     ],
     "requirements": [
-        "pydanfossally@git+https://github.com/MTrab/pydanfossally.git@master"
+        "pydanfossally==1.0.3"
     ],
     "version": "2.0.1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pytest-asyncio==1.3.0
 pytest-cov==7.0.0
 pip>=21.0,<26.1
 ruff==0.15.6
-pydanfossally@git+https://github.com/MTrab/pydanfossally.git@master
+pydanfossally==1.0.3


### PR DESCRIPTION
## Summary
- update `custom_components/danfoss_ally/manifest.json` to use `pydanfossally==1.0.3`
- update `requirements.txt` to use `pydanfossally==1.0.3`

## Test Strategy
- `ruff format --check .`
- `ruff check .`
- attempted `python -m pip install -r requirements.txt`

## Known Limitations
- `pydanfossally==1.0.3` is published on PyPI, but this environment still resolves only up to `1.0.2`, which looks like temporary PyPI/CDN propagation delay
- proposed semver label: `patch` pending confirmation

## Configuration Changes
- no user-facing configuration changes