### PR TITLE
Increase Danfoss Ally polling interval to 60 seconds

### DIFF
--- a/custom_components/danfoss_ally/const.py
+++ b/custom_components/danfoss_ally/const.py
@@ -14,7 +14,7 @@ CONF_SECRET = "secret"
 DEFAULT_NAME = "Danfoss"
 DOMAIN = "danfoss_ally"
 API_TIMEOUT = 30.0
-SCAN_INTERVAL = timedelta(seconds=45)
+SCAN_INTERVAL = timedelta(seconds=60)
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,


### PR DESCRIPTION
## Summary
- increase `SCAN_INTERVAL` from 45 seconds to 60 seconds to reduce polling pressure on the Danfoss API

## Test Strategy
- `ruff format .`
- `ruff check .`

## Known Limitations
- no functional behavior changes beyond a slightly slower polling cadence
- proposed semver label: `patch` pending confirmation

## Configuration Changes
- no user-facing configuration changes