### PR TITLE
Raise HACS minimum Home Assistant version to 2026.3.0

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
     "name": "Danfoss Ally",
     "render_readme": true,
-    "homeassistant": "2024.5.0",
+    "homeassistant": "2026.3.0",
     "zip_release": true,
     "filename": "danfoss_ally.zip"
 }


### PR DESCRIPTION
## Summary
- raise the HACS minimum Home Assistant version in `hacs.json` from `2024.5.0` to `2026.3.0`
- align the HACS compatibility gate with the first Home Assistant release line that uses Python 3.14

## Test Strategy
- `ruff format .`
- `ruff check .`

## Known Limitations
- this does not change runtime code; it only prevents HACS from offering the integration to unsupported Home Assistant versions
- proposed semver label: `patch` pending confirmation

## Configuration Changes
- no user-facing configuration changes