### PR TITLE
Use parenthesized exception handlers for compatibility

### DIFF
--- a/custom_components/danfoss_ally/binary_sensor.py
+++ b/custom_components/danfoss_ally/binary_sensor.py
@@ -172,5 +172,5 @@ class DanfossAllyBinarySensor(DanfossAllyEntity, BinarySensorEntity):
         """Return the current binary sensor state."""
         try:
             return self.entity_description.value_fn(self.device)
-        except KeyError, TypeError:
+        except (KeyError, TypeError):
             return False

--- a/custom_components/danfoss_ally/const.py
+++ b/custom_components/danfoss_ally/const.py
@@ -43,7 +43,7 @@ def _load_integration_version() -> str:
     try:
         with manifest_path.open(encoding="utf-8") as manifest_file:
             return str(json.load(manifest_file)["version"])
-    except OSError, KeyError, TypeError, ValueError:
+    except (OSError, KeyError, TypeError, ValueError):
         return "unknown"
 
 

--- a/custom_components/danfoss_ally/sensor.py
+++ b/custom_components/danfoss_ally/sensor.py
@@ -149,7 +149,7 @@ class DanfossAllySensor(DanfossAllyEntity, SensorEntity):
         """Return the current sensor value."""
         try:
             return self.entity_description.value_fn(self.device)
-        except KeyError, TypeError:
+        except (KeyError, TypeError):
             return None
 
     @property


### PR DESCRIPTION
## Summary
- replace Python 3.14-only unparenthesized multi-exception handlers with the compatible parenthesized form
- restore startup compatibility for Home Assistant environments still running Python 3.13

## Test Strategy
- `ruff format .`
- `ruff check .`
- `pytest -q tests/test_sensor.py tests/test_coordinator.py tests/test_climate.py tests/test_switch.py tests/test_entity.py`

## Known Limitations
- no functional behavior changes beyond restoring Python 3.13 compatibility
- semver label confirmed: `patch`

## Configuration Changes
- no user-facing configuration changes

Fixes #330