### PR TITLE
Revert Python 3.13 Ruff target back to Python 3.14

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,6 @@
 # The contents of this file is based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 
-target-version = "py313"
+target-version = "py314"
 
 [lint]
 select = [


### PR DESCRIPTION
## Summary
- revert the `.ruff.toml` target version from `py313` back to `py314`
- keep the repository aligned with the project requirement that tooling and tests target Python 3.14

## Test Strategy
- `ruff format .`
- `ruff check .`

## Known Limitations
- this only reverts the Ruff target-version change from #333
- proposed semver label: `patch` pending confirmation

## Configuration Changes
- no user-facing configuration changes

Fixes #333