### PR TITLE
Pin Danfoss Ally to the fixed pydanfossally commit

### DIFF
--- a/custom_components/danfoss_ally/manifest.json
+++ b/custom_components/danfoss_ally/manifest.json
@@ -9,7 +9,7 @@
     "issue_tracker": "https://github.com/MTrab/danfoss_ally/issues",
     "loggers": ["pydanfossally"],
     "requirements": [
-        "pydanfossally@git+https://github.com/MTrab/pydanfossally.git@861928556ca500d126634e107aefc282ced51365"
+        "pydanfossally@git+https://github.com/MTrab/pydanfossally.git@9ed024ce7586009456a186a50a1c9e30589295ed"
     ],
     "version": "2.0.3"
 }


### PR DESCRIPTION
## Summary
Update the Danfoss Ally integration manifest to pin `pydanfossally` to the merged upstream commit that fixes stricter Poetry metadata handling for git-based installs.

## Test strategy
- `ruff check custom_components/danfoss_ally`
- `python` JSON parse of `custom_components/danfoss_ally/manifest.json`

## Known limitations
`ruff format --check custom_components/danfoss_ally` currently reports existing formatting drift in `custom_components/danfoss_ally/binary_sensor.py` and `custom_components/danfoss_ally/sensor.py`, which are unrelated to this change.

## Configuration changes
None.
