### PR TITLE
Bump pydanfossally

### DIFF
--- a/custom_components/danfoss_ally/manifest.json
+++ b/custom_components/danfoss_ally/manifest.json
@@ -13,7 +13,7 @@
         "pydanfossally"
     ],
     "requirements": [
-        "pydanfossally@git+https://github.com/MTrab/pydanfossally.git@9ed024ce7586009456a186a50a1c9e30589295ed"
+        "pydanfossally==1.1.0"
     ],
     "version": "2.0.4b1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pytest-asyncio==1.3.0
 pytest-cov==7.0.0
 pip>=21.0,<26.1
 ruff==0.15.7
-pydanfossally==1.0.4
+pydanfossally==1.1.0


### PR DESCRIPTION
## Description
Update the integration dependency references from the previous pydanfossally release/git pin to the published pydanfossally==1.1.0 package in both the Home Assistant manifest and local requirements.

## Test Strategy
Ran ruff format .
Ran ruff check .

## Known Limitations
No runtime validation was performed against physical hardware in this change.

## Required Configuration Changes
None.

## Proposed Semver Label
patch (not applied yet; needs explicit verification before any label is set)
