### PR TITLE
Restore thermostat hvac_action when work_state reports NoHeat

### DIFF
--- a/custom_components/danfoss_ally/climate.py
+++ b/custom_components/danfoss_ally/climate.py
@@ -189,22 +189,26 @@ class DanfossAllyClimate(DanfossAllyEntity, ClimateEntity):
         work_state = self.device_value("work_state")
         valve_opening = self.device_value("valve_opening", "valveOpening")
 
-        if output_status is not None:
-            if not output_status:
-                return HVACAction.IDLE
-            if work_state in {"Cool", "cool_active"}:
-                return HVACAction.COOLING
+        if work_state in {"NoHeat", "idle"}:
+            return HVACAction.IDLE
+        if work_state in {"Cool", "cool_active"}:
+            return HVACAction.COOLING
+        if work_state in {"Heat", "heat_active"}:
+            if valve_opening is not None:
+                return (
+                    HVACAction.HEATING if float(valve_opening) > 1 else HVACAction.IDLE
+                )
             return HVACAction.HEATING
+
+        if output_status is not None and not output_status:
+            return HVACAction.IDLE
 
         if valve_opening is not None:
             return HVACAction.HEATING if float(valve_opening) > 1 else HVACAction.IDLE
 
-        if work_state in {"Heat", "heat_active"}:
-            return HVACAction.HEATING
-        if work_state in {"Cool", "cool_active"}:
-            return HVACAction.COOLING
-        if work_state in {"NoHeat", "idle"}:
-            return HVACAction.IDLE
+        if output_status is not None:
+            return HVACAction.HEATING if output_status else HVACAction.IDLE
+
         return None
 
     @property

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -246,3 +246,66 @@ def test_hvac_action_uses_valve_opening_before_work_state() -> None:
     entity = DanfossAllyClimate(coordinator, "device-1")
 
     assert entity.hvac_action.value == "idle"
+
+
+def test_hvac_action_prefers_no_heat_work_state_over_output_status() -> None:
+    """A NoHeat work_state should not be forced into heating by output_status."""
+    coordinator = FakeCoordinator(
+        {
+            "device-1": make_device(
+                output_status=True,
+                work_state="NoHeat",
+            )
+        }
+    )
+    entity = DanfossAllyClimate(coordinator, "device-1")
+
+    assert entity.hvac_action.value == "idle"
+
+
+def test_hvac_action_uses_heat_work_state_when_valve_opening_missing() -> None:
+    """A Heat work_state should still report heating without valve telemetry."""
+    coordinator = FakeCoordinator(
+        {
+            "device-1": make_device(
+                output_status=True,
+                work_state="Heat",
+                valve_opening=None,
+            )
+        }
+    )
+    entity = DanfossAllyClimate(coordinator, "device-1")
+
+    assert entity.hvac_action.value == "heating"
+
+
+def test_hvac_action_uses_valve_opening_for_heat_work_state() -> None:
+    """Valve opening should confirm active heating when Heat is reported."""
+    coordinator = FakeCoordinator(
+        {
+            "device-1": make_device(
+                output_status=None,
+                valve_opening=18,
+                work_state="Heat",
+            )
+        }
+    )
+    entity = DanfossAllyClimate(coordinator, "device-1")
+
+    assert entity.hvac_action.value == "heating"
+
+
+def test_hvac_action_falls_back_to_output_status_without_work_state() -> None:
+    """Devices without work_state should still use output_status as a fallback."""
+    coordinator = FakeCoordinator(
+        {
+            "device-1": make_device(
+                output_status=False,
+                work_state=None,
+                valve_opening=None,
+            )
+        }
+    )
+    entity = DanfossAllyClimate(coordinator, "device-1")
+
+    assert entity.hvac_action.value == "idle"


### PR DESCRIPTION
## Summary
This restores hvac_action prioritization so thermostat entities report idle when the Ally API reports work_state=NoHeat, even if output_status is still true.

The change keeps valve_opening as a correction signal for stale Heat states and retains fallback behavior for devices that do not expose a usable work_state.

Fixes #347

## Status
Draft PR pending final clarification from Danfoss on the intended relationship between work_state, output_status, and valve_opening. The current implementation is based on observed API behavior and existing regression expectations, but we are waiting for Danfoss to confirm the authoritative semantics.

## Test strategy
- ruff format custom_components/danfoss_ally/climate.py tests/test_climate.py
- ruff check custom_components/danfoss_ally/climate.py tests/test_climate.py
- pytest tests/test_climate.py

## Known limitations
This change relies on the current understanding that work_state is the best indicator of active heating versus idle, while output_status and valve_opening are fallback or correction signals. Physical hardware validation has not been performed in this change.

## Configuration changes
None.

## Proposed semver label
patch
Not set on the PR; awaiting explicit confirmation before any label change.
