### PR TITLE
Clean up Danfoss Ally climate presets and icons

### DIFF
--- a/custom_components/danfoss_ally/climate.py
+++ b/custom_components/danfoss_ally/climate.py
@@ -22,10 +22,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 
 from .const import (
-    LEGACY_PRESET_ALIASES,
-    PRESET_HOLIDAY_AWAY,
-    PRESET_HOLIDAY_HOME,
-    PRESET_MANUAL,
+    PRESET_HOLIDAY,
     PRESET_PAUSE,
 )
 from .coordinator import DanfossConfigEntry
@@ -40,9 +37,7 @@ PRESET_TO_MODE = {
     PRESET_HOME: "at_home",
     PRESET_AWAY: "leaving_home",
     PRESET_PAUSE: "pause",
-    PRESET_MANUAL: "manual",
-    PRESET_HOLIDAY_HOME: "holiday_sat",
-    PRESET_HOLIDAY_AWAY: "holiday",
+    PRESET_HOLIDAY: "holiday",
 }
 
 MODE_TO_PRESET = {value: key for key, value in PRESET_TO_MODE.items()}
@@ -121,9 +116,7 @@ class DanfossAllyClimate(DanfossAllyEntity, ClimateEntity):
             PRESET_HOME,
             PRESET_AWAY,
             PRESET_PAUSE,
-            PRESET_MANUAL,
-            PRESET_HOLIDAY_HOME,
-            PRESET_HOLIDAY_AWAY,
+            PRESET_HOLIDAY,
         ]
 
     @property
@@ -160,7 +153,7 @@ class DanfossAllyClimate(DanfossAllyEntity, ClimateEntity):
         work_state = self.device_value("work_state")
 
         if self._is_icon_device:
-            if mode in {"at_home", "leaving_home", "holiday_sat", "holiday", "pause"}:
+            if mode in {"at_home", "leaving_home", "holiday", "pause"}:
                 return HVACMode.AUTO
             if work_state in {"Heat", "heat_active"}:
                 if self.device_value("manual_mode_fast") == self.device_value(
@@ -176,7 +169,7 @@ class DanfossAllyClimate(DanfossAllyEntity, ClimateEntity):
                 return HVACMode.COOL
             return HVACMode.AUTO
 
-        if mode in {"at_home", "leaving_home", "holiday_sat"}:
+        if mode in {"at_home", "leaving_home"}:
             return HVACMode.AUTO
         if mode in {"manual", "pause", "holiday"}:
             return HVACMode.HEAT
@@ -416,8 +409,7 @@ class DanfossAllyClimate(DanfossAllyEntity, ClimateEntity):
         }.issubset(self.device)
 
     def _normalize_preset_mode(self, preset_mode: str) -> str:
-        """Normalize legacy preset aliases to the new tokens."""
-        preset_mode = LEGACY_PRESET_ALIASES.get(preset_mode, preset_mode)
+        """Validate supported preset names."""
         if preset_mode not in PRESET_TO_MODE:
             raise ValueError(f"Unsupported preset mode: {preset_mode}")
         return preset_mode
@@ -460,8 +452,6 @@ class DanfossAllyClimate(DanfossAllyEntity, ClimateEntity):
             return "manual_mode_fast"
         if mode == "holiday":
             return "holiday_setting"
-        if mode == "holiday_sat":
-            return "at_home_setting"
         return "manual_mode_fast"
 
     def _get_setpoint_for_mode(self, mode: str | None) -> float | None:

--- a/custom_components/danfoss_ally/const.py
+++ b/custom_components/danfoss_ally/const.py
@@ -30,15 +30,8 @@ PLATFORMS: list[Platform] = [
     Platform.SELECT,
 ]
 
-PRESET_MANUAL = "manual"
 PRESET_PAUSE = "pause"
-PRESET_HOLIDAY_AWAY = "holiday_away"
-PRESET_HOLIDAY_HOME = "holiday_home"
-
-LEGACY_PRESET_ALIASES = {
-    "holiday": PRESET_HOLIDAY_AWAY,
-    "holiday_sat": PRESET_HOLIDAY_HOME,
-}
+PRESET_HOLIDAY = "holiday"
 
 ACTION_TYPE_SET_PRESET_TEMPERATURE = "set_preset_temperature"
 

--- a/custom_components/danfoss_ally/icons.json
+++ b/custom_components/danfoss_ally/icons.json
@@ -1,7 +1,27 @@
 {
-    "services": {
-      "set_preset_temperature": "mdi:thermometer",
-      "set_window_state_open": "mdi:window-open",
-      "set_external_temperature": "mdi:home-thermometer"
+  "entity": {
+    "climate": {
+      "thermostat": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "holiday": "mdi:palm-tree",
+              "pause": "mdi:pause-circle-outline"
+            }
+          }
+        }
+      }
+    }
+  },
+  "services": {
+    "set_preset_temperature": {
+      "service": "mdi:thermometer"
+    },
+    "set_window_state_open": {
+      "service": "mdi:window-open"
+    },
+    "set_external_temperature": {
+      "service": "mdi:home-thermometer"
     }
   }
+}

--- a/custom_components/danfoss_ally/services.yaml
+++ b/custom_components/danfoss_ally/services.yaml
@@ -27,14 +27,10 @@ set_preset_temperature:
               value: "home"
             - label: "Away"
               value: "away"
-            - label: "Manual"
-              value: "manual"
             - label: "Pause"
               value: "pause"
-            - label: "Holiday (Home)"
-              value: "holiday_home"
-            - label: "Holiday (Away)"
-              value: "holiday_away"
+            - label: "Holiday"
+              value: "holiday"
 
 set_window_state_open:
   name: Set window open state

--- a/custom_components/danfoss_ally/translations/da.json
+++ b/custom_components/danfoss_ally/translations/da.json
@@ -86,10 +86,8 @@
           "preset_mode": {
             "state": {
               "away": "Væk",
-              "holiday_away": "Ferie (væk)",
-              "holiday_home": "Ferie (hjemme)",
+              "holiday": "Ferie",
               "home": "Hjemme",
-              "manual": "Manuel",
               "pause": "Pause"
             }
           }

--- a/custom_components/danfoss_ally/translations/de.json
+++ b/custom_components/danfoss_ally/translations/de.json
@@ -86,10 +86,8 @@
           "preset_mode": {
             "state": {
               "away": "Abwesend",
-              "holiday_away": "Urlaub (abwesend)",
-              "holiday_home": "Urlaub (zuhause)",
+              "holiday": "Urlaub",
               "home": "Zuhause",
-              "manual": "Manuell",
               "pause": "Pause"
             }
           }

--- a/custom_components/danfoss_ally/translations/en.json
+++ b/custom_components/danfoss_ally/translations/en.json
@@ -86,10 +86,8 @@
           "preset_mode": {
             "state": {
               "away": "Away",
-              "holiday_away": "Holiday (Away)",
-              "holiday_home": "Holiday (Home)",
+              "holiday": "Holiday",
               "home": "Home",
-              "manual": "Manual",
               "pause": "Pause"
             }
           }

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant.components.climate.const import PRESET_HOME
 
 from custom_components.danfoss_ally.climate import DanfossAllyClimate
+from custom_components.danfoss_ally.const import PRESET_HOLIDAY, PRESET_PAUSE
 
 
 class FakeCoordinator:
@@ -161,6 +162,30 @@ async def test_set_preset_temperature_switches_to_requested_schedule_mode() -> N
             {"mode": "at_home", "at_home_setting": 19.0},
         ),
     ]
+
+
+def test_preset_modes_only_expose_supported_api_presets() -> None:
+    """Only real API-backed presets should be exposed."""
+    coordinator = FakeCoordinator({"device-1": make_device(mode="manual")})
+    entity = DanfossAllyClimate(coordinator, "device-1")
+
+    assert entity.preset_modes == [PRESET_HOME, "away", PRESET_PAUSE, PRESET_HOLIDAY]
+
+
+def test_manual_mode_has_no_preset() -> None:
+    """Manual is a mode, not a preset."""
+    coordinator = FakeCoordinator({"device-1": make_device(mode="manual")})
+    entity = DanfossAllyClimate(coordinator, "device-1")
+
+    assert entity.preset_mode is None
+
+
+def test_holiday_mode_maps_to_holiday_preset() -> None:
+    """Holiday should be exposed as a single preset."""
+    coordinator = FakeCoordinator({"device-1": make_device(mode="holiday")})
+    entity = DanfossAllyClimate(coordinator, "device-1")
+
+    assert entity.preset_mode == PRESET_HOLIDAY
 
 
 def test_current_temperature_prefers_external_sensor_when_radiator_is_covered() -> None:


### PR DESCRIPTION
## Summary
This cleans up the climate preset model to match the actual Danfoss Ally API modes more closely.

The integration now exposes only the schedule-backed presets `home`, `away`, `pause`, and `holiday`. Legacy and invented preset names such as `holiday_home`, `holiday_away`, and `holiday_sat` are removed from the user-facing preset layer, and `manual` is no longer exposed as a preset because it is treated as an operating mode rather than a schedule preset.

The PR also adds preset-specific icons for the remaining custom presets so the climate entity can show dedicated icons for `pause` and `holiday`.

## Test strategy
- `python -m json.tool custom_components/danfoss_ally/icons.json >/dev/null`
- `ruff check custom_components/danfoss_ally/const.py custom_components/danfoss_ally/climate.py tests/test_climate.py`
- `pytest tests/test_climate.py`

## Known limitations
This change does not alter Home Assistant's built-in climate HVAC mode model, so manual operation still appears under the standard HVAC mode semantics rather than as a dedicated `manual` HVAC state.

The new preset icons follow Home Assistant's integration icon format, but I have not verified their rendering in a live frontend session in this branch.

## Configuration changes
None.

## Proposed semver label
`patch`
Not set on the PR; awaiting explicit confirmation before any label change.
