### PR TITLE
Add setting external temperature sensor directly in thermostat config

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,9 @@ on:
 jobs:
   autolabel_pull_requests:
     name: Autolabel pull requests
-    if: github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,42 +1,42 @@
 # The contents of this file is based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 
-target-version = "py314"
+target-version = "py313"
 
 [lint]
 select = [
-    "B007", # Loop control variable {name} not used within loop body
-    "B014", # Exception handler with duplicate exception
-    "C",  # complexity
-    "D",  # docstrings
-    "E",  # pycodestyle
-    "F",  # pyflakes/autoflake
-    "ICN001", # import concentions; {name} should be imported as {asname}
+    "B007",    # Loop control variable {name} not used within loop body
+    "B014",    # Exception handler with duplicate exception
+    "C",       # complexity
+    "D",       # docstrings
+    "E",       # pycodestyle
+    "F",       # pyflakes/autoflake
+    "ICN001",  # import concentions; {name} should be imported as {asname}
     "PGH004",  # Use specific rule codes when using noqa
     "PLC0414", # Useless import alias. Import alias does not rename original package.
-    "SIM105", # Use contextlib.suppress({exception}) instead of try-except-pass
-    "SIM117", # Merge with-statements that use the same scope
-    "SIM118", # Use {key} in {dict} instead of {key} in {dict}.keys()
-    "SIM201", # Use {left} != {right} instead of not {left} == {right}
-    "SIM212", # Use {a} if {a} else {b} instead of {b} if not {a} else {a}
-    "SIM300", # Yoda conditions. Use 'age == 42' instead of '42 == age'.
-    "SIM401", # Use get from dict with default instead of an if block
-    "T20",  # flake8-print
-    "TRY004", # Prefer TypeError exception for invalid type
-    "RUF006", # Store a reference to the return value of asyncio.create_task
-    "UP",  # pyupgrade
-    "W",  # pycodestyle
+    "SIM105",  # Use contextlib.suppress({exception}) instead of try-except-pass
+    "SIM117",  # Merge with-statements that use the same scope
+    "SIM118",  # Use {key} in {dict} instead of {key} in {dict}.keys()
+    "SIM201",  # Use {left} != {right} instead of not {left} == {right}
+    "SIM212",  # Use {a} if {a} else {b} instead of {b} if not {a} else {a}
+    "SIM300",  # Yoda conditions. Use 'age == 42' instead of '42 == age'.
+    "SIM401",  # Use get from dict with default instead of an if block
+    "T20",     # flake8-print
+    "TRY004",  # Prefer TypeError exception for invalid type
+    "RUF006",  # Store a reference to the return value of asyncio.create_task
+    "UP",      # pyupgrade
+    "W",       # pycodestyle
 ]
 
 ignore = [
-    "D202",  # No blank lines allowed after function docstring
-    "D203",  # 1 blank line required before class docstring
-    "D213",  # Multi-line docstring summary should start at the second line
-    "D404",  # First word of the docstring should not be This
-    "D406",  # Section name should end with a newline
-    "D407",  # Section name underlining
-    "D411",  # Missing blank line before section
-    "E501",  # line too long
-    "E731",  # do not assign a lambda expression, use a def
+    "D202", # No blank lines allowed after function docstring
+    "D203", # 1 blank line required before class docstring
+    "D213", # Multi-line docstring summary should start at the second line
+    "D404", # First word of the docstring should not be This
+    "D406", # Section name should end with a newline
+    "D407", # Section name underlining
+    "D411", # Missing blank line before section
+    "E501", # line too long
+    "E731", # do not assign a lambda expression, use a def
 ]
 
 [lint.flake8-pytest-style]

--- a/custom_components/danfoss_ally/__init__.py
+++ b/custom_components/danfoss_ally/__init__.py
@@ -127,10 +127,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: DanfossConfigEntry) -> b
         raise
 
     entry.runtime_data = DanfossAllyRuntimeData(client=client, coordinator=coordinator)
-    
+
     # Setup external temperature listeners
     await coordinator.async_setup_external_temp_listeners()
-    
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
@@ -156,7 +156,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: DanfossConfigEntry) -> 
     """Unload a config entry."""
     # Cleanup external temperature listeners
     await entry.runtime_data.coordinator.async_unload_external_temp_listeners()
-    
+
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         await entry.runtime_data.client.aclose()

--- a/custom_components/danfoss_ally/__init__.py
+++ b/custom_components/danfoss_ally/__init__.py
@@ -127,6 +127,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: DanfossConfigEntry) -> b
         raise
 
     entry.runtime_data = DanfossAllyRuntimeData(client=client, coordinator=coordinator)
+    
+    # Setup external temperature listeners
+    await coordinator.async_setup_external_temp_listeners()
+    
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
@@ -150,6 +154,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: DanfossConfigEntry) -> bool:
     """Unload a config entry."""
+    # Cleanup external temperature listeners
+    await entry.runtime_data.coordinator.async_unload_external_temp_listeners()
+    
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         await entry.runtime_data.client.aclose()

--- a/custom_components/danfoss_ally/binary_sensor.py
+++ b/custom_components/danfoss_ally/binary_sensor.py
@@ -172,5 +172,5 @@ class DanfossAllyBinarySensor(DanfossAllyEntity, BinarySensorEntity):
         """Return the current binary sensor state."""
         try:
             return self.entity_description.value_fn(self.device)
-        except KeyError, TypeError:
+        except (KeyError, TypeError):
             return False

--- a/custom_components/danfoss_ally/config_flow.py
+++ b/custom_components/danfoss_ally/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from pydanfossally import DanfossAlly, exceptions
 
-from .const import API_TIMEOUT, CONF_KEY, CONF_SECRET, DOMAIN, USER_AGENT_PREFIX
+from .const import API_TIMEOUT, CONF_KEY, CONF_SECRET, DOMAIN, USER_AGENT_PREFIX, CONF_EXTERNAL_SENSORS, CONF_ENTITY_ID
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -131,8 +131,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     )
                     if duplicate_abort is not None:
                         return duplicate_abort
+                    
+                    # Initialize external sensors config
+                    entry_data = {
+                        **user_input,
+                        CONF_EXTERNAL_SENSORS: {},
+                    }
+                    
                     return self.async_create_entry(
-                        title=validated["title"], data=user_input
+                        title=validated["title"], data=entry_data
                     )
 
                 entry = (
@@ -166,6 +173,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return None
 
 
+ConfigFlow.async_get_options_flow = staticmethod(  # type: ignore[assignment]
+    lambda config_entry: OptionsFlowHandler(config_entry)
+)
+
+
 class CannotConnect(HomeAssistantError):
     """Error to indicate we cannot connect."""
 
@@ -192,3 +204,161 @@ class InvalidAuth(HomeAssistantError):
 
 class UnknownError(HomeAssistantError):
     """Error to indicate an unexpected integration or API failure."""
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options for Danfoss Ally."""
+
+    async def async_step_init(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        """Manage options."""
+        return await self.async_step_configure_devices(user_input)
+
+    async def async_step_configure_devices(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        """Select which device to configure external temperature sensor for."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            selected_device_id = user_input.get("device_id")
+            if selected_device_id:
+                return await self.async_step_configure_device_sensor(
+                    device_id=selected_device_id
+                )
+
+        # Get coordinator from entry runtime data
+        coordinator = None
+        if self.config_entry and hasattr(self.config_entry, "runtime_data"):
+            if self.config_entry.runtime_data:
+                coordinator = self.config_entry.runtime_data.coordinator
+
+        devices = {}
+        if coordinator and coordinator.data:
+            # Build list of thermostat devices
+            for device_id, device_data in coordinator.data.items():
+                if device_data.get("isThermostat"):
+                    device_name = device_data.get("name", device_id)
+                    devices[device_id] = device_name
+
+        if not devices:
+            return self.async_abort(reason="no_devices")
+
+        schema = vol.Schema({
+            vol.Required("device_id"): vol.In(devices),
+        })
+
+        return self.async_show_form(
+            step_id="configure_devices",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={"devices": str(len(devices))},
+        )
+
+    async def async_step_configure_device_sensor(
+        self,
+        user_input: dict[str, Any] | None = None,
+        device_id: str | None = None,
+    ) -> FlowResult:
+        """Configure external temperature sensor for a specific device."""
+        errors: dict[str, str] = {}
+
+        # Get device_id from user input if not provided
+        if device_id is None and user_input and "device_id" in user_input:
+            device_id = user_input["device_id"]
+
+        if device_id is None:
+            return await self.async_step_configure_devices()
+
+        NONE_OPTION = "— ingen sensor —"
+
+        if user_input is not None:
+            raw_entity = user_input.get(CONF_ENTITY_ID, "")
+            selected_entity = "" if (not raw_entity or raw_entity == NONE_OPTION) else raw_entity
+
+            # Update entry data with external sensors configuration
+            current_external_sensors = dict(
+                self.config_entry.data.get(CONF_EXTERNAL_SENSORS, {})
+            )
+            had_sensor = device_id in current_external_sensors
+
+            if selected_entity:
+                current_external_sensors[device_id] = selected_entity
+            else:
+                current_external_sensors.pop(device_id, None)
+
+            # If sensor was removed, send -8000 to disable on device before reload
+            if had_sensor and not selected_entity:
+                coordinator = None
+                if hasattr(self.config_entry, "runtime_data") and self.config_entry.runtime_data:
+                    coordinator = self.config_entry.runtime_data.coordinator
+                if coordinator:
+                    await coordinator.async_disable_external_temperature(device_id)
+
+            # Update config entry
+            self.hass.config_entries.async_update_entry(
+                self.config_entry,
+                data={
+                    **self.config_entry.data,
+                    CONF_EXTERNAL_SENSORS: current_external_sensors,
+                },
+            )
+
+            # Reload the entry to apply changes
+            await self.hass.config_entries.async_reload(self.config_entry.entry_id)
+
+            return self.async_abort(reason="external_sensor_configured")
+
+        # Get coordinator from entry runtime data
+        coordinator = None
+        if hasattr(self.config_entry, "runtime_data") and self.config_entry.runtime_data:
+            coordinator = self.config_entry.runtime_data.coordinator
+
+        # Get device name for display
+        device_name = device_id
+        if coordinator and coordinator.data and device_id in coordinator.data:
+            device_name = coordinator.data[device_id].get("name", device_id)
+
+        # Build entity selector - allow any entity with temperature-like state
+        entity_options = {}
+        for state in self.hass.states.async_all():
+            # Look for entities with numeric state (temperature sensors, climate entities, etc.)
+            try:
+                float(state.state)
+                # Include unit_of_measurement if present
+                unit = state.attributes.get("unit_of_measurement", "")
+                if unit:
+                    entity_options[state.entity_id] = f"{state.entity_id} ({unit})"
+                else:
+                    entity_options[state.entity_id] = state.entity_id
+            except (ValueError, TypeError):
+                continue
+
+        if not entity_options:
+            errors["base"] = "no_entities"
+
+        # Get current selection for this device
+        current_external_sensors = self.config_entry.data.get(CONF_EXTERNAL_SENSORS, {})
+        current_entity = current_external_sensors.get(device_id, "")
+
+        # Add a blank option so the user can clear the selection
+        options_with_none = {NONE_OPTION: NONE_OPTION, **entity_options}
+
+        schema = vol.Schema({
+            vol.Optional(
+                CONF_ENTITY_ID,
+                default=current_entity if current_entity in entity_options else NONE_OPTION,
+            ): vol.In(options_with_none),
+        })
+
+        return self.async_show_form(
+            step_id="configure_device_sensor",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={
+                "device": device_name,
+            },
+        )

--- a/custom_components/danfoss_ally/config_flow.py
+++ b/custom_components/danfoss_ally/config_flow.py
@@ -8,13 +8,19 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from pydanfossally import DanfossAlly, exceptions
 
-from .const import API_TIMEOUT, CONF_KEY, CONF_SECRET, DOMAIN, USER_AGENT_PREFIX, CONF_EXTERNAL_SENSORS, CONF_ENTITY_ID
+from .const import (
+    API_TIMEOUT,
+    CONF_EXTERNAL_SENSORS,
+    CONF_KEY,
+    CONF_SECRET,
+    DOMAIN,
+    USER_AGENT_PREFIX,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -173,14 +179,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="already_configured")
         return None
 
-    @staticmethod
-    @callback
-    def async_get_options_flow(
-        config_entry: ConfigEntry,
-    ) -> OptionsFlowHandler:
-        """Return the options flow handler."""
-        return OptionsFlowHandler()
-
 
 class CannotConnect(HomeAssistantError):
     """Error to indicate we cannot connect."""
@@ -208,161 +206,3 @@ class InvalidAuth(HomeAssistantError):
 
 class UnknownError(HomeAssistantError):
     """Error to indicate an unexpected integration or API failure."""
-
-
-class OptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle options for Danfoss Ally."""
-
-    async def async_step_init(
-        self,
-        user_input: dict[str, Any] | None = None,
-    ) -> FlowResult:
-        """Manage options."""
-        return await self.async_step_configure_devices(user_input)
-
-    async def async_step_configure_devices(
-        self,
-        user_input: dict[str, Any] | None = None,
-    ) -> FlowResult:
-        """Select which device to configure external temperature sensor for."""
-        errors: dict[str, str] = {}
-
-        if user_input is not None:
-            selected_device_id = user_input.get("device_id")
-            if selected_device_id:
-                return await self.async_step_configure_device_sensor(
-                    device_id=selected_device_id
-                )
-
-        # Get coordinator from entry runtime data
-        coordinator = None
-        if self.config_entry and hasattr(self.config_entry, "runtime_data"):
-            if self.config_entry.runtime_data:
-                coordinator = self.config_entry.runtime_data.coordinator
-
-        devices = {}
-        if coordinator and coordinator.data:
-            # Build list of thermostat devices
-            for device_id, device_data in coordinator.data.items():
-                if device_data.get("isThermostat"):
-                    device_name = device_data.get("name", device_id)
-                    devices[device_id] = device_name
-
-        if not devices:
-            return self.async_abort(reason="no_devices")
-
-        schema = vol.Schema({
-            vol.Required("device_id"): vol.In(devices),
-        })
-
-        return self.async_show_form(
-            step_id="configure_devices",
-            data_schema=schema,
-            errors=errors,
-            description_placeholders={"devices": str(len(devices))},
-        )
-
-    async def async_step_configure_device_sensor(
-        self,
-        user_input: dict[str, Any] | None = None,
-        device_id: str | None = None,
-    ) -> FlowResult:
-        """Configure external temperature sensor for a specific device."""
-        errors: dict[str, str] = {}
-
-        # Get device_id from user input if not provided
-        if device_id is None and user_input and "device_id" in user_input:
-            device_id = user_input["device_id"]
-
-        if device_id is None:
-            return await self.async_step_configure_devices()
-
-        NONE_OPTION = "— ingen sensor —"
-
-        if user_input is not None:
-            raw_entity = user_input.get(CONF_ENTITY_ID, "")
-            selected_entity = "" if (not raw_entity or raw_entity == NONE_OPTION) else raw_entity
-
-            # Update entry data with external sensors configuration
-            current_external_sensors = dict(
-                self.config_entry.data.get(CONF_EXTERNAL_SENSORS, {})
-            )
-            had_sensor = device_id in current_external_sensors
-
-            if selected_entity:
-                current_external_sensors[device_id] = selected_entity
-            else:
-                current_external_sensors.pop(device_id, None)
-
-            # If sensor was removed, send -8000 to disable on device before reload
-            if had_sensor and not selected_entity:
-                coordinator = None
-                if hasattr(self.config_entry, "runtime_data") and self.config_entry.runtime_data:
-                    coordinator = self.config_entry.runtime_data.coordinator
-                if coordinator:
-                    await coordinator.async_disable_external_temperature(device_id)
-
-            # Update config entry
-            self.hass.config_entries.async_update_entry(
-                self.config_entry,
-                data={
-                    **self.config_entry.data,
-                    CONF_EXTERNAL_SENSORS: current_external_sensors,
-                },
-            )
-
-            # Reload the entry to apply changes
-            await self.hass.config_entries.async_reload(self.config_entry.entry_id)
-
-            return self.async_abort(reason="external_sensor_configured")
-
-        # Get coordinator from entry runtime data
-        coordinator = None
-        if hasattr(self.config_entry, "runtime_data") and self.config_entry.runtime_data:
-            coordinator = self.config_entry.runtime_data.coordinator
-
-        # Get device name for display
-        device_name = device_id
-        if coordinator and coordinator.data and device_id in coordinator.data:
-            device_name = coordinator.data[device_id].get("name", device_id)
-
-        # Build entity selector - allow any entity with temperature-like state
-        entity_options = {}
-        for state in self.hass.states.async_all():
-            # Look for entities with numeric state (temperature sensors, climate entities, etc.)
-            try:
-                float(state.state)
-                # Include unit_of_measurement if present
-                unit = state.attributes.get("unit_of_measurement", "")
-                if unit:
-                    entity_options[state.entity_id] = f"{state.entity_id} ({unit})"
-                else:
-                    entity_options[state.entity_id] = state.entity_id
-            except (ValueError, TypeError):
-                continue
-
-        if not entity_options:
-            errors["base"] = "no_entities"
-
-        # Get current selection for this device
-        current_external_sensors = self.config_entry.data.get(CONF_EXTERNAL_SENSORS, {})
-        current_entity = current_external_sensors.get(device_id, "")
-
-        # Add a blank option so the user can clear the selection
-        options_with_none = {NONE_OPTION: NONE_OPTION, **entity_options}
-
-        schema = vol.Schema({
-            vol.Optional(
-                CONF_ENTITY_ID,
-                default=current_entity if current_entity in entity_options else NONE_OPTION,
-            ): vol.In(options_with_none),
-        })
-
-        return self.async_show_form(
-            step_id="configure_device_sensor",
-            data_schema=schema,
-            errors=errors,
-            description_placeholders={
-                "device": device_name,
-            },
-        )

--- a/custom_components/danfoss_ally/config_flow.py
+++ b/custom_components/danfoss_ally/config_flow.py
@@ -138,13 +138,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     )
                     if duplicate_abort is not None:
                         return duplicate_abort
-                    
+
                     # Initialize external sensors config
                     entry_data = {
                         **user_input,
                         CONF_EXTERNAL_SENSORS: {},
                     }
-                    
+
                     return self.async_create_entry(
                         title=validated["title"], data=entry_data
                     )

--- a/custom_components/danfoss_ally/config_flow.py
+++ b/custom_components/danfoss_ally/config_flow.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
@@ -172,10 +173,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="already_configured")
         return None
 
-
-ConfigFlow.async_get_options_flow = staticmethod(  # type: ignore[assignment]
-    lambda config_entry: OptionsFlowHandler(config_entry)
-)
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> OptionsFlowHandler:
+        """Return the options flow handler."""
+        return OptionsFlowHandler()
 
 
 class CannotConnect(HomeAssistantError):

--- a/custom_components/danfoss_ally/const.py
+++ b/custom_components/danfoss_ally/const.py
@@ -44,7 +44,7 @@ def _load_integration_version() -> str:
     try:
         with manifest_path.open(encoding="utf-8") as manifest_file:
             return str(json.load(manifest_file)["version"])
-    except OSError, KeyError, TypeError, ValueError:
+    except (OSError, KeyError, TypeError, ValueError):
         return "unknown"
 
 

--- a/custom_components/danfoss_ally/const.py
+++ b/custom_components/danfoss_ally/const.py
@@ -10,6 +10,8 @@ from homeassistant.const import Platform
 
 CONF_KEY = "key"
 CONF_SECRET = "secret"
+CONF_EXTERNAL_SENSORS = "external_sensors"
+CONF_ENTITY_ID = "entity_id"
 
 DEFAULT_NAME = "Danfoss"
 DOMAIN = "danfoss_ally"

--- a/custom_components/danfoss_ally/coordinator.py
+++ b/custom_components/danfoss_ally/coordinator.py
@@ -90,6 +90,16 @@ class PendingWrite:
     baseline_response_time: int | None
 
 
+@dataclass(slots=True)
+class ExternalTempState:
+    """Track external temperature state for a device."""
+
+    entity_id: str
+    last_sent_value: float | None  # in Celsius
+    last_sent_at: float  # timestamp
+    unsub_state_listener: Any | None = None
+
+
 DanfossConfigEntry = ConfigEntry
 
 
@@ -114,6 +124,7 @@ class DanfossAllyDataUpdateCoordinator(
         )
         self.client = client
         self._pending_writes: dict[str, PendingWrite] = {}
+        self._external_temp_states: dict[str, ExternalTempState] = {}
         self._refresh_in_progress = False
 
     async def _async_update_data(self) -> dict[str, dict[str, Any]]:
@@ -337,6 +348,213 @@ class DanfossAllyDataUpdateCoordinator(
             optimistic_updates=optimistic_updates,
             error_message=f"Failed to send command for {device_id}",
         )
+
+    @property
+    def external_sensors_config(self) -> dict[str, str]:
+        """Return configured external sensor entity IDs by device ID."""
+        if self.config_entry is None:
+            return {}
+        return self.config_entry.data.get("external_sensors", {})
+
+    async def async_setup_external_temp_listeners(self) -> None:
+        """Setup state change listeners for all configured external temperature sensors."""
+        from .const import CONF_ENTITY_ID, CONF_EXTERNAL_SENSORS
+        from homeassistant.core import callback
+        from homeassistant.helpers.event import async_track_state_change
+
+        # Clear any existing listeners
+        await self._async_unload_external_temp_listeners()
+
+        external_sensors = self.config_entry.data.get(CONF_EXTERNAL_SENSORS, {})
+        if not external_sensors:
+            return
+
+        _LOGGER.debug("Setting up external temperature listeners for devices: %s", list(external_sensors.keys()))
+
+        for device_id, entity_id in external_sensors.items():
+            if not entity_id:
+                continue
+
+            @callback
+            def handle_state_change(
+                entity_id: str,
+                old_state: Any,
+                new_state: Any,
+                device_id: str = device_id,
+            ) -> None:
+                """Handle external temperature entity state change."""
+                if new_state is None or new_state.state == "unavailable":
+                    return
+                self.hass.async_create_task(
+                    self._async_handle_external_temp_change(device_id, new_state.state, entity_id)
+                )
+
+            # Register state listener
+            unsub = async_track_state_change(
+                self.hass,
+                [entity_id],
+                handle_state_change,
+            )
+
+            # Store listener for cleanup
+            self._external_temp_states[device_id] = ExternalTempState(
+                entity_id=entity_id,
+                last_sent_value=None,
+                last_sent_at=0,
+                unsub_state_listener=unsub,
+            )
+            _LOGGER.debug("External temp listener subscribed for device %s to entity %s", device_id, entity_id)
+
+    async def _async_unload_external_temp_listeners(self) -> None:
+        """Unsubscribe from all external temperature state listeners."""
+        for state in self._external_temp_states.values():
+            if state.unsub_state_listener:
+                state.unsub_state_listener()
+        self._external_temp_states.clear()
+
+    async def async_disable_external_temperature(self, device_id: str) -> None:
+        """Send -8000 to disable external temperature on the device and remove listener."""
+        _LOGGER.debug("Disabling external temperature for device %s", device_id)
+
+        # Remove listener for this device only
+        state = self._external_temp_states.pop(device_id, None)
+        if state and state.unsub_state_listener:
+            state.unsub_state_listener()
+
+        # Send -8000 to signal device to disable external temperature
+        try:
+            await self._async_run_write(
+                device_id,
+                self.client.send_command(device_id, [("ext_measured_rs", -8000)]),
+                optimistic_updates=None,
+                error_message=f"Failed to disable external temperature for {device_id}",
+            )
+            _LOGGER.debug("External temperature disabled on device %s", device_id)
+        except HomeAssistantError as err:
+            _LOGGER.warning("Failed to disable external temperature: %s", err)
+
+    async def _async_handle_external_temp_change(
+        self,
+        device_id: str,
+        new_state_str: str,
+        entity_id: str,
+    ) -> None:
+        """Handle external temperature entity state change and send to device if needed."""
+        try:
+            # Get the new state value from Home Assistant
+            state = self.hass.states.get(entity_id)
+            if state is None or state.state == "unavailable":
+                _LOGGER.debug(
+                    "External temp entity %s is unavailable, not sending update",
+                    entity_id,
+                )
+                return
+
+            try:
+                temp_celsius = float(state.state)
+            except (ValueError, TypeError):
+                _LOGGER.warning(
+                    "External temp entity %s has invalid state value: %s",
+                    entity_id,
+                    state.state,
+                )
+                return
+
+            # Get current state tracking
+            current_state = self._external_temp_states.get(device_id)
+            if current_state is None:
+                current_state = ExternalTempState(
+                    entity_id=entity_id,
+                    last_sent_value=None,
+                    last_sent_at=0,
+                    unsub_state_listener=None,
+                )
+                self._external_temp_states[device_id] = current_state
+
+            # Check if value has actually changed
+            if current_state.last_sent_value == temp_celsius:
+                _LOGGER.debug(
+                    "External temp for device %s unchanged (%.1f°C), skipping send",
+                    device_id,
+                    temp_celsius,
+                )
+                return
+
+            # Send the temperature
+            await self._async_send_external_temperature(device_id, temp_celsius)
+
+            # Schedule next re-send in 30 minutes if value hasn't changed
+            self._async_schedule_external_temp_resend(device_id, temp_celsius)
+
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.exception("Error handling external temp change: %s", err)
+
+    async def _async_send_external_temperature(
+        self,
+        device_id: str,
+        temp_celsius: float,
+    ) -> None:
+        """Send external temperature to device via API."""
+        # Convert to 0.01°C units (21.0°C → 2100)
+        temp_value = int(round(temp_celsius * 100))
+
+        _LOGGER.debug(
+            "Sending external temperature %.1f°C (value: %d) to device %s",
+            temp_celsius,
+            temp_value,
+            device_id,
+        )
+
+        try:
+            await self._async_run_write(
+                device_id,
+                self.client.send_command(device_id, [("ext_measured_rs", temp_value)]),
+                optimistic_updates=None,
+                error_message=f"Failed to send external temperature to {device_id}",
+            )
+
+            # Update tracking after successful send
+            current_state = self._external_temp_states.get(device_id)
+            if current_state:
+                current_state.last_sent_value = temp_celsius
+                current_state.last_sent_at = time.monotonic()
+
+        except HomeAssistantError as err:
+            _LOGGER.warning("Failed to send external temperature: %s", err)
+
+    def _async_schedule_external_temp_resend(
+        self,
+        device_id: str,
+        temp_celsius: float,
+    ) -> None:
+        """Schedule external temperature re-send in 30 minutes."""
+        from homeassistant.helpers.event import async_call_later
+        
+        async def resend_callback(now: Any) -> None:  # now is datetime, not used
+            # Check if still configured
+            if device_id not in self.external_sensors_config:
+                return
+            
+            # Check if value has changed
+            current_state = self._external_temp_states.get(device_id)
+            if current_state and current_state.last_sent_value == temp_celsius:
+                _LOGGER.debug(
+                    "Re-sending external temperature %.1f°C to device %s (30-min timer)",
+                    temp_celsius,
+                    device_id,
+                )
+                await self._async_send_external_temperature(device_id, temp_celsius)
+
+        # Schedule for 30 minutes from now
+        async_call_later(
+            self.hass,
+            30 * 60,  # 1800 seconds
+            resend_callback,
+        )
+
+    async def async_unload_external_temp_listeners(self) -> None:
+        """Public method to unload listeners."""
+        await self._async_unload_external_temp_listeners()
 
     async def _async_run_write(
         self,

--- a/custom_components/danfoss_ally/coordinator.py
+++ b/custom_components/danfoss_ally/coordinator.py
@@ -364,6 +364,8 @@ class DanfossAllyDataUpdateCoordinator(
         """Return entity IDs that can provide a temperature value."""
         options: list[str] = []
         for state in self.hass.states.async_all():
+            if not self._is_temperature_entity(state):
+                continue
             if self._extract_temperature_celsius(state) is None:
                 continue
             options.append(state.entity_id)
@@ -599,6 +601,24 @@ class DanfossAllyDataUpdateCoordinator(
     async def async_unload_external_temp_listeners(self) -> None:
         """Public method to unload listeners."""
         await self._async_unload_external_temp_listeners()
+
+    def _is_temperature_entity(self, state: Any) -> bool:
+        """Return whether an entity should be offered as a temperature source."""
+        entity_id = getattr(state, "entity_id", "")
+        if not entity_id or "." not in entity_id:
+            return False
+
+        domain = entity_id.split(".", 1)[0]
+        device_class = state.attributes.get("device_class")
+        unit = state.attributes.get("unit_of_measurement")
+
+        if device_class == "temperature":
+            return True
+
+        if unit in {"°C", "°F", "K"}:
+            return True
+
+        return domain == "climate" and state.attributes.get("current_temperature") is not None
 
     def _extract_temperature_celsius(self, state: Any) -> float | None:
         """Extract a temperature value from a state object."""

--- a/custom_components/danfoss_ally/coordinator.py
+++ b/custom_components/danfoss_ally/coordinator.py
@@ -402,7 +402,7 @@ class DanfossAllyDataUpdateCoordinator(
         await self.async_disable_external_temperature(device_id)
 
     async def async_setup_external_temp_listeners(self) -> None:
-        """Setup state change listeners for all configured external temperature sensors."""
+        """Set up state change listeners for all configured external temperature sensors."""
         from homeassistant.core import callback
         from homeassistant.helpers.event import async_track_state_change
 
@@ -613,7 +613,7 @@ class DanfossAllyDataUpdateCoordinator(
 
     def _is_temperature_entity(self, state: Any) -> bool:
         """Return whether an entity should be offered as a temperature source."""
-        if not state.domain == "sensor":
+        if state.domain != "sensor":
             return False
 
         entity_id = getattr(state, "entity_id", "")

--- a/custom_components/danfoss_ally/coordinator.py
+++ b/custom_components/danfoss_ally/coordinator.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable
-from dataclasses import dataclass
 import logging
 import math
 import time
+from collections.abc import Awaitable
+from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -413,7 +413,10 @@ class DanfossAllyDataUpdateCoordinator(
         if not external_sensors:
             return
 
-        _LOGGER.debug("Setting up external temperature listeners for devices: %s", list(external_sensors.keys()))
+        _LOGGER.debug(
+            "Setting up external temperature listeners for devices: %s",
+            list(external_sensors.keys()),
+        )
 
         for device_id, entity_id in external_sensors.items():
             if not entity_id:
@@ -430,7 +433,9 @@ class DanfossAllyDataUpdateCoordinator(
                 if new_state is None or new_state.state == "unavailable":
                     return
                 self.hass.async_create_task(
-                    self._async_handle_external_temp_change(device_id, new_state.state, entity_id)
+                    self._async_handle_external_temp_change(
+                        device_id, new_state.state, entity_id
+                    )
                 )
 
             # Register state listener
@@ -447,7 +452,11 @@ class DanfossAllyDataUpdateCoordinator(
                 last_sent_at=0,
                 unsub_state_listener=unsub,
             )
-            _LOGGER.debug("External temp listener subscribed for device %s to entity %s", device_id, entity_id)
+            _LOGGER.debug(
+                "External temp listener subscribed for device %s to entity %s",
+                device_id,
+                entity_id,
+            )
             self.hass.async_create_task(
                 self._async_handle_external_temp_change(device_id, "", entity_id)
             )
@@ -575,12 +584,12 @@ class DanfossAllyDataUpdateCoordinator(
     ) -> None:
         """Schedule external temperature re-send in 30 minutes."""
         from homeassistant.helpers.event import async_call_later
-        
+
         async def resend_callback(now: Any) -> None:  # now is datetime, not used
             # Check if still configured
             if device_id not in self.external_sensors_config:
                 return
-            
+
             # Check if value has changed
             current_state = self._external_temp_states.get(device_id)
             if current_state and current_state.last_sent_value == temp_celsius:
@@ -604,6 +613,9 @@ class DanfossAllyDataUpdateCoordinator(
 
     def _is_temperature_entity(self, state: Any) -> bool:
         """Return whether an entity should be offered as a temperature source."""
+        if not state.domain == "sensor":
+            return False
+
         entity_id = getattr(state, "entity_id", "")
         if not entity_id or "." not in entity_id:
             return False
@@ -618,7 +630,10 @@ class DanfossAllyDataUpdateCoordinator(
         if unit in {"°C", "°F", "K"}:
             return True
 
-        return domain == "climate" and state.attributes.get("current_temperature") is not None
+        return (
+            domain == "climate"
+            and state.attributes.get("current_temperature") is not None
+        )
 
     def _extract_temperature_celsius(self, state: Any) -> float | None:
         """Extract a temperature value from a state object."""

--- a/custom_components/danfoss_ally/coordinator.py
+++ b/custom_components/danfoss_ally/coordinator.py
@@ -15,7 +15,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pydanfossally import DanfossAlly, exceptions
 
-from .const import DOMAIN, SCAN_INTERVAL
+from .const import CONF_EXTERNAL_SENSORS, DOMAIN, SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 PENDING_WRITE_TIMEOUT = 60.0
@@ -354,18 +354,60 @@ class DanfossAllyDataUpdateCoordinator(
         """Return configured external sensor entity IDs by device ID."""
         if self.config_entry is None:
             return {}
-        return self.config_entry.data.get("external_sensors", {})
+        return self.config_entry.data.get(CONF_EXTERNAL_SENSORS, {})
+
+    def get_external_sensor_entity_id(self, device_id: str) -> str | None:
+        """Return configured external sensor entity ID for one device."""
+        return self.external_sensors_config.get(device_id)
+
+    def get_temperature_entity_options(self) -> list[str]:
+        """Return entity IDs that can provide a temperature value."""
+        options: list[str] = []
+        for state in self.hass.states.async_all():
+            if self._extract_temperature_celsius(state) is None:
+                continue
+            options.append(state.entity_id)
+
+        options.sort()
+        return options
+
+    async def async_set_external_sensor_entity(
+        self,
+        device_id: str,
+        entity_id: str | None,
+    ) -> None:
+        """Persist the external sensor mapping and apply runtime listeners."""
+        current_map = dict(self.external_sensors_config)
+
+        if entity_id:
+            current_map[device_id] = entity_id
+        else:
+            current_map.pop(device_id, None)
+
+        self.hass.config_entries.async_update_entry(
+            self.config_entry,
+            data={
+                **self.config_entry.data,
+                CONF_EXTERNAL_SENSORS: current_map,
+            },
+        )
+
+        if entity_id:
+            await self.async_setup_external_temp_listeners()
+            await self._async_handle_external_temp_change(device_id, "", entity_id)
+            return
+
+        await self.async_disable_external_temperature(device_id)
 
     async def async_setup_external_temp_listeners(self) -> None:
         """Setup state change listeners for all configured external temperature sensors."""
-        from .const import CONF_ENTITY_ID, CONF_EXTERNAL_SENSORS
         from homeassistant.core import callback
         from homeassistant.helpers.event import async_track_state_change
 
         # Clear any existing listeners
         await self._async_unload_external_temp_listeners()
 
-        external_sensors = self.config_entry.data.get(CONF_EXTERNAL_SENSORS, {})
+        external_sensors = self.external_sensors_config
         if not external_sensors:
             return
 
@@ -404,6 +446,9 @@ class DanfossAllyDataUpdateCoordinator(
                 unsub_state_listener=unsub,
             )
             _LOGGER.debug("External temp listener subscribed for device %s to entity %s", device_id, entity_id)
+            self.hass.async_create_task(
+                self._async_handle_external_temp_change(device_id, "", entity_id)
+            )
 
     async def _async_unload_external_temp_listeners(self) -> None:
         """Unsubscribe from all external temperature state listeners."""
@@ -450,9 +495,8 @@ class DanfossAllyDataUpdateCoordinator(
                 )
                 return
 
-            try:
-                temp_celsius = float(state.state)
-            except (ValueError, TypeError):
+            temp_celsius = self._extract_temperature_celsius(state)
+            if temp_celsius is None:
                 _LOGGER.warning(
                     "External temp entity %s has invalid state value: %s",
                     entity_id,
@@ -555,6 +599,25 @@ class DanfossAllyDataUpdateCoordinator(
     async def async_unload_external_temp_listeners(self) -> None:
         """Public method to unload listeners."""
         await self._async_unload_external_temp_listeners()
+
+    def _extract_temperature_celsius(self, state: Any) -> float | None:
+        """Extract a temperature value from a state object."""
+        if state is None:
+            return None
+
+        try:
+            return float(state.state)
+        except (ValueError, TypeError):
+            pass
+
+        current_temperature = state.attributes.get("current_temperature")
+        if current_temperature is None:
+            return None
+
+        try:
+            return float(current_temperature)
+        except (ValueError, TypeError):
+            return None
 
     async def _async_run_write(
         self,

--- a/custom_components/danfoss_ally/select.py
+++ b/custom_components/danfoss_ally/select.py
@@ -39,7 +39,9 @@ def _build_entities(
     coordinator,
 ) -> list[DanfossAllyHcsSelect | DanfossAllyExternalTemperatureSensorSelect]:
     """Build select entities for currently discovered devices."""
-    entities: list[DanfossAllyHcsSelect | DanfossAllyExternalTemperatureSensorSelect] = []
+    entities: list[
+        DanfossAllyHcsSelect | DanfossAllyExternalTemperatureSensorSelect
+    ] = []
     for device_id, device in (coordinator.data or {}).items():
         if "ctrl_alg" in device:
             entities.append(DanfossAllyHcsSelect(coordinator, device_id))

--- a/custom_components/danfoss_ally/select.py
+++ b/custom_components/danfoss_ally/select.py
@@ -93,6 +93,7 @@ class DanfossAllyExternalTemperatureSensorSelect(DanfossAllyEntity, SelectEntity
     _attr_entity_category = EntityCategory.CONFIG
     _attr_icon = "mdi:thermometer-lines"
     _attr_translation_key = "external_temperature_sensor_source"
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator, device_id: str) -> None:
         """Initialize the external temperature sensor source select."""

--- a/custom_components/danfoss_ally/select.py
+++ b/custom_components/danfoss_ally/select.py
@@ -9,6 +9,8 @@ from homeassistant.helpers.entity import EntityCategory
 from .coordinator import DanfossConfigEntry
 from .entity import DanfossAllyEntity, async_setup_dynamic_platform_entities
 
+EXTERNAL_SENSOR_DISABLED = "disabled"
+
 HCS_OPTIONS = {
     "quick": 1,
     "moderate": 5,
@@ -33,13 +35,21 @@ async def async_setup_entry(
     async_setup_dynamic_platform_entities(entry, async_add_entities, _build_entities)
 
 
-def _build_entities(coordinator) -> list[DanfossAllyHcsSelect]:
+def _build_entities(
+    coordinator,
+) -> list[DanfossAllyHcsSelect | DanfossAllyExternalTemperatureSensorSelect]:
     """Build select entities for currently discovered devices."""
-    return [
-        DanfossAllyHcsSelect(coordinator, device_id)
-        for device_id, device in (coordinator.data or {}).items()
-        if "ctrl_alg" in device
-    ]
+    entities: list[DanfossAllyHcsSelect | DanfossAllyExternalTemperatureSensorSelect] = []
+    for device_id, device in (coordinator.data or {}).items():
+        if "ctrl_alg" in device:
+            entities.append(DanfossAllyHcsSelect(coordinator, device_id))
+
+        if device.get("isThermostat"):
+            entities.append(
+                DanfossAllyExternalTemperatureSensorSelect(coordinator, device_id)
+            )
+
+    return entities
 
 
 class DanfossAllyHcsSelect(DanfossAllyEntity, SelectEntity):
@@ -75,3 +85,47 @@ class DanfossAllyHcsSelect(DanfossAllyEntity, SelectEntity):
             [("ctrl_alg", value)],
             optimistic_updates={"ctrl_alg": value},
         )
+
+
+class DanfossAllyExternalTemperatureSensorSelect(DanfossAllyEntity, SelectEntity):
+    """Select which HA entity should provide external room temperature."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:thermometer-lines"
+    _attr_translation_key = "external_temperature_sensor_source"
+
+    def __init__(self, coordinator, device_id: str) -> None:
+        """Initialize the external temperature sensor source select."""
+        super().__init__(coordinator, device_id)
+        self._attr_unique_id = f"external_temperature_sensor_source_{device_id}_ally"
+
+    @property
+    def current_option(self) -> str | None:
+        """Return currently selected source entity ID."""
+        return (
+            self.coordinator.get_external_sensor_entity_id(self._device_id)
+            or EXTERNAL_SENSOR_DISABLED
+        )
+
+    @property
+    def options(self) -> list[str]:
+        """Return all selectable temperature source entities."""
+        options = [
+            EXTERNAL_SENSOR_DISABLED,
+            *self.coordinator.get_temperature_entity_options(),
+        ]
+
+        current = self.current_option
+        if current and current not in options:
+            options.append(current)
+
+        return options
+
+    async def async_select_option(self, option: str) -> None:
+        """Persist selected source and apply runtime behavior immediately."""
+        entity_id = None if option == EXTERNAL_SENSOR_DISABLED else option
+        await self.coordinator.async_set_external_sensor_entity(
+            self._device_id,
+            entity_id,
+        )
+        self.async_write_ha_state()

--- a/custom_components/danfoss_ally/sensor.py
+++ b/custom_components/danfoss_ally/sensor.py
@@ -149,7 +149,7 @@ class DanfossAllySensor(DanfossAllyEntity, SensorEntity):
         """Return the current sensor value."""
         try:
             return self.entity_description.value_fn(self.device)
-        except KeyError, TypeError:
+        except (KeyError, TypeError):
             return None
 
     @property

--- a/custom_components/danfoss_ally/translations/da.json
+++ b/custom_components/danfoss_ally/translations/da.json
@@ -119,6 +119,12 @@
           "quick": "Hurtig (5 min)",
           "slow": "Langsom (80 min)"
         }
+      },
+      "external_temperature_sensor_source": {
+        "name": "Ekstern temperaturkilde",
+        "state": {
+          "disabled": "Deaktiveret"
+        }
       }
     },
     "sensor": {
@@ -159,31 +165,6 @@
       },
       "heat_available": {
         "name": "Varme tilgængelig"
-      }
-    }
-  },
-  "options": {
-    "abort": {
-      "no_devices": "Ingen termostater blev fundet.",
-      "external_sensor_configured": "Ekstern temperaturfølger er konfigureret."
-    },
-    "error": {
-      "no_entities": "Ingen enheder med en numerisk tilstand blev fundet."
-    },
-    "step": {
-      "configure_devices": {
-        "title": "Konfigurer ekstern temperaturfølger",
-        "description": "Vælg den termostat du vil konfigurere en ekstern temperaturfølger for.",
-        "data": {
-          "device_id": "Termostat"
-        }
-      },
-      "configure_device_sensor": {
-        "title": "Vælg temperaturfølger",
-        "description": "Vælg den enhed der skal bruges som ekstern temperaturmåling for **{device}**. Vælg '— ingen sensor —' for at deaktivere.",
-        "data": {
-          "entity_id": "Temperaturfølger enhed"
-        }
       }
     }
   }

--- a/custom_components/danfoss_ally/translations/da.json
+++ b/custom_components/danfoss_ally/translations/da.json
@@ -161,5 +161,30 @@
         "name": "Varme tilgængelig"
       }
     }
+  },
+  "options": {
+    "abort": {
+      "no_devices": "Ingen termostater blev fundet.",
+      "external_sensor_configured": "Ekstern temperaturfølger er konfigureret."
+    },
+    "error": {
+      "no_entities": "Ingen enheder med en numerisk tilstand blev fundet."
+    },
+    "step": {
+      "configure_devices": {
+        "title": "Konfigurer ekstern temperaturfølger",
+        "description": "Vælg den termostat du vil konfigurere en ekstern temperaturfølger for.",
+        "data": {
+          "device_id": "Termostat"
+        }
+      },
+      "configure_device_sensor": {
+        "title": "Vælg temperaturfølger",
+        "description": "Vælg den enhed der skal bruges som ekstern temperaturmåling for **{device}**. Vælg '— ingen sensor —' for at deaktivere.",
+        "data": {
+          "entity_id": "Temperaturfølger enhed"
+        }
+      }
+    }
   }
 }

--- a/custom_components/danfoss_ally/translations/de.json
+++ b/custom_components/danfoss_ally/translations/de.json
@@ -119,6 +119,12 @@
           "quick": "Schnell (5 Min.)",
           "slow": "Langsam (80 Min.)"
         }
+      },
+      "external_temperature_sensor_source": {
+        "name": "Externe Temperaturquelle",
+        "state": {
+          "disabled": "Deaktiviert"
+        }
       }
     },
     "sensor": {
@@ -159,31 +165,6 @@
       },
       "heat_available": {
         "name": "Wärme verfügbar"
-      }
-    }
-  },
-  "options": {
-    "abort": {
-      "no_devices": "Keine Thermostate gefunden.",
-      "external_sensor_configured": "Externer Temperatursensor wurde konfiguriert."
-    },
-    "error": {
-      "no_entities": "Keine Entitäten mit einem numerischen Zustand gefunden."
-    },
-    "step": {
-      "configure_devices": {
-        "title": "Externen Temperatursensor konfigurieren",
-        "description": "Wählen Sie den Thermostat, für den Sie einen externen Temperatursensor konfigurieren möchten.",
-        "data": {
-          "device_id": "Thermostat"
-        }
-      },
-      "configure_device_sensor": {
-        "title": "Temperatursensor auswählen",
-        "description": "Wählen Sie die Entität, die als externe Temperaturmessung für **{device}** verwendet werden soll. Wählen Sie '— ingen sensor —' zum Deaktivieren.",
-        "data": {
-          "entity_id": "Temperatursensor-Entität"
-        }
       }
     }
   }

--- a/custom_components/danfoss_ally/translations/de.json
+++ b/custom_components/danfoss_ally/translations/de.json
@@ -161,5 +161,30 @@
         "name": "Wärme verfügbar"
       }
     }
+  },
+  "options": {
+    "abort": {
+      "no_devices": "Keine Thermostate gefunden.",
+      "external_sensor_configured": "Externer Temperatursensor wurde konfiguriert."
+    },
+    "error": {
+      "no_entities": "Keine Entitäten mit einem numerischen Zustand gefunden."
+    },
+    "step": {
+      "configure_devices": {
+        "title": "Externen Temperatursensor konfigurieren",
+        "description": "Wählen Sie den Thermostat, für den Sie einen externen Temperatursensor konfigurieren möchten.",
+        "data": {
+          "device_id": "Thermostat"
+        }
+      },
+      "configure_device_sensor": {
+        "title": "Temperatursensor auswählen",
+        "description": "Wählen Sie die Entität, die als externe Temperaturmessung für **{device}** verwendet werden soll. Wählen Sie '— ingen sensor —' zum Deaktivieren.",
+        "data": {
+          "entity_id": "Temperatursensor-Entität"
+        }
+      }
+    }
   }
 }

--- a/custom_components/danfoss_ally/translations/en.json
+++ b/custom_components/danfoss_ally/translations/en.json
@@ -161,5 +161,30 @@
         "name": "Heat available"
       }
     }
+  },
+  "options": {
+    "abort": {
+      "no_devices": "No thermostats were found.",
+      "external_sensor_configured": "External temperature sensor has been configured."
+    },
+    "error": {
+      "no_entities": "No entities with a numeric state were found."
+    },
+    "step": {
+      "configure_devices": {
+        "title": "Configure external temperature sensor",
+        "description": "Select the thermostat you want to configure an external temperature sensor for.",
+        "data": {
+          "device_id": "Thermostat"
+        }
+      },
+      "configure_device_sensor": {
+        "title": "Select temperature sensor",
+        "description": "Select the temperature sensor entity to use as the external reading for **{device}**. Choose '— ingen sensor —' to disable.",
+        "data": {
+          "entity_id": "Temperature sensor entity"
+        }
+      }
+    }
   }
 }

--- a/custom_components/danfoss_ally/translations/en.json
+++ b/custom_components/danfoss_ally/translations/en.json
@@ -119,6 +119,12 @@
           "quick": "Quick (5 min)",
           "slow": "Slow (80 min)"
         }
+      },
+      "external_temperature_sensor_source": {
+        "name": "External temperature source",
+        "state": {
+          "disabled": "Disabled"
+        }
       }
     },
     "sensor": {
@@ -159,31 +165,6 @@
       },
       "heat_available": {
         "name": "Heat available"
-      }
-    }
-  },
-  "options": {
-    "abort": {
-      "no_devices": "No thermostats were found.",
-      "external_sensor_configured": "External temperature sensor has been configured."
-    },
-    "error": {
-      "no_entities": "No entities with a numeric state were found."
-    },
-    "step": {
-      "configure_devices": {
-        "title": "Configure external temperature sensor",
-        "description": "Select the thermostat you want to configure an external temperature sensor for.",
-        "data": {
-          "device_id": "Thermostat"
-        }
-      },
-      "configure_device_sensor": {
-        "title": "Select temperature sensor",
-        "description": "Select the temperature sensor entity to use as the external reading for **{device}**. Choose '— ingen sensor —' to disable.",
-        "data": {
-          "entity_id": "Temperature sensor entity"
-        }
       }
     }
   }


### PR DESCRIPTION
I have made an extension of your integration. It is possible with these changes to send an external temperature reading to the danfoss api that the thermostat can use instead of the internal sensor. It is made so that you just select a temperature entity in the configuration card, and then handle the rest of the integration yourself.
Are you interested in including it in the integration.??

If it does not completely follow your standard for integration, it is made with AI, so please excuse if there are errors in the code. I have tested it on my own HA, and it runs fine and the api receives the reading.


![danfoss ally](https://github.com/user-attachments/assets/b53b4037-9e61-4cb1-848e-c1bf3f28879f)
