### PR TITLE
Tame runtime Danfoss Ally rate-limit logs

### DIFF
--- a/custom_components/danfoss_ally/coordinator.py
+++ b/custom_components/danfoss_ally/coordinator.py
@@ -39,12 +39,48 @@ FORBIDDEN_RETRY_AFTER = 1800.0
 RATE_LIMIT_RETRY_AFTER = 900.0
 SERVER_ERROR_RETRY_AFTER = 600.0
 GENERIC_API_RETRY_AFTER = 300.0
+RATE_LIMIT_ERROR_MESSAGE = "Danfoss Ally API rate limit reached (HTTP 429)."
 AUTH_FAILED_MESSAGE = (
     "Authentication failed. Check your Consumer Key and Consumer Secret."
 )
 WINDOW_SENSOR_DELAY = 60.0
 WINDOW_RESTORE_STORE_KEY = f"{DOMAIN}_window_restore"
 WINDOW_RESTORE_STORE_VERSION = 1
+
+
+class _CoordinatorLoggerAdapter(logging.LoggerAdapter):
+    """Adjust coordinator log severity for expected runtime failures."""
+
+    def __init__(
+        self,
+        logger: logging.Logger,
+        coordinator: DanfossAllyDataUpdateCoordinator,
+    ) -> None:
+        """Initialize the adapter."""
+        super().__init__(logger, extra={})
+        self._coordinator = coordinator
+
+    def error(self, msg: object, *args: object, **kwargs: object) -> None:
+        """Downgrade runtime rate-limit refresh failures to warnings."""
+        if self._should_warn_for_runtime_rate_limit(msg, args):
+            self.warning(msg, *args, **kwargs)
+            return
+
+        super().error(msg, *args, **kwargs)
+
+    def _should_warn_for_runtime_rate_limit(
+        self,
+        msg: object,
+        args: tuple[object, ...],
+    ) -> bool:
+        """Return True when a runtime refresh rate-limit should be a warning."""
+        if not getattr(self._coordinator, "_runtime_refresh_logging", False):
+            return False
+
+        if msg != "Error fetching %s data: %s" or len(args) < 2:
+            return False
+
+        return args[0] == DOMAIN and str(args[1]) == RATE_LIMIT_ERROR_MESSAGE
 
 
 def _format_error(err: BaseException) -> str:
@@ -63,7 +99,7 @@ def _describe_api_error(err: BaseException) -> str:
     if isinstance(err, exceptions.ForbiddenError):
         return "Danfoss Ally API denied access (HTTP 403)."
     if isinstance(err, exceptions.RateLimitError):
-        return "Danfoss Ally API rate limit reached (HTTP 429)."
+        return RATE_LIMIT_ERROR_MESSAGE
     if isinstance(err, exceptions.InternalServerError):
         return "Danfoss Ally API server error (HTTP 5xx)."
     if isinstance(err, exceptions.BadRequestError):
@@ -170,6 +206,27 @@ class DanfossAllyDataUpdateCoordinator(
         self._window_restore_states: dict[str, WindowRestoreState] = {}
         self._window_restore_loaded = False
         self._refresh_in_progress = False
+        self._runtime_refresh_logging = False
+        self.logger = _CoordinatorLoggerAdapter(_LOGGER, self)
+
+    async def _async_refresh(
+        self,
+        log_failures: bool = True,
+        raise_on_auth_failed: bool = False,
+        scheduled: bool = False,
+        raise_on_entry_error: bool = False,
+    ) -> None:
+        """Track whether refresh logging is happening during runtime."""
+        self._runtime_refresh_logging = not raise_on_entry_error
+        try:
+            await super()._async_refresh(
+                log_failures=log_failures,
+                raise_on_auth_failed=raise_on_auth_failed,
+                scheduled=scheduled,
+                raise_on_entry_error=raise_on_entry_error,
+            )
+        finally:
+            self._runtime_refresh_logging = False
 
     async def _async_update_data(self) -> dict[str, dict[str, Any]]:
         """Fetch the latest device list."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
@@ -14,6 +15,7 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 from pydanfossally import exceptions
 from custom_components.danfoss_ally.coordinator import (
     CONNECTION_RETRY_AFTER,
+    RATE_LIMIT_ERROR_MESSAGE,
     DanfossAllyDataUpdateCoordinator,
     FORBIDDEN_RETRY_AFTER,
     GENERIC_API_RETRY_AFTER,
@@ -22,7 +24,9 @@ from custom_components.danfoss_ally.coordinator import (
     SERVER_ERROR_RETRY_AFTER,
     TIMEOUT_RETRY_AFTER,
     WindowRestoreState,
+    _CoordinatorLoggerAdapter,
 )
+from custom_components.danfoss_ally.const import DOMAIN
 
 
 def test_apply_pending_writes_overlays_stale_polled_values() -> None:
@@ -313,6 +317,50 @@ async def test_async_request_refresh_calls_super_when_idle() -> None:
         await coordinator.async_request_refresh()
 
     super_request_refresh.assert_awaited_once()
+
+
+def test_runtime_rate_limit_refresh_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Runtime HTTP 429 refresh failures should be warnings, not errors."""
+    coordinator = object.__new__(DanfossAllyDataUpdateCoordinator)
+    coordinator._runtime_refresh_logging = True
+    logger = _CoordinatorLoggerAdapter(logging.getLogger(__name__), coordinator)
+
+    with caplog.at_level(logging.WARNING):
+        logger.error(
+            "Error fetching %s data: %s",
+            DOMAIN,
+            UpdateFailed(RATE_LIMIT_ERROR_MESSAGE),
+        )
+
+    assert (
+        "Error fetching danfoss_ally data: Danfoss Ally API rate limit reached (HTTP 429)."
+        in caplog.text
+    )
+    assert [record.levelno for record in caplog.records] == [logging.WARNING]
+
+
+def test_startup_rate_limit_refresh_logs_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Startup HTTP 429 refresh failures should remain errors."""
+    coordinator = object.__new__(DanfossAllyDataUpdateCoordinator)
+    coordinator._runtime_refresh_logging = False
+    logger = _CoordinatorLoggerAdapter(logging.getLogger(__name__), coordinator)
+
+    with caplog.at_level(logging.ERROR):
+        logger.error(
+            "Error fetching %s data: %s",
+            DOMAIN,
+            UpdateFailed(RATE_LIMIT_ERROR_MESSAGE),
+        )
+
+    assert (
+        "Error fetching danfoss_ally data: Danfoss Ally API rate limit reached (HTTP 429)."
+        in caplog.text
+    )
+    assert [record.levelno for record in caplog.records] == [logging.ERROR]
 
 
 class FakeStates:


### PR DESCRIPTION
## Summary
Downgrade coordinator refresh logging for Danfoss Ally HTTP 429 responses from error to warning after the integration has completed startup. Startup failures still remain errors so Home Assistant continues its normal setup retry behavior.

## Test strategy
Ran `ruff format custom_components/danfoss_ally/coordinator.py tests/test_coordinator.py`
Ran `ruff check custom_components/danfoss_ally/coordinator.py tests/test_coordinator.py`
Ran `pytest tests/test_coordinator.py`

## Known limitations
This only changes log severity for runtime refresh rate-limit failures. Retry timing and startup handling are unchanged.

## Configuration changes
No configuration changes required.

## Semver
Proposed semver label: `patch` (pending verification with maintainer before any label is set).
