### PR TITLE
Keep open window state tied to detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ This feature reduces heating when a window is open. The thermostat can detect th
 - **Open window detection** enables or disables the feature.
 - **Open window** shows whether the thermostat currently considers a window to be open.
 
+When **Open window detection** is turned off, the native **Open window** binary sensor becomes unavailable, and the `Set window open state` service is blocked until the feature is enabled again.
+
 ### Window pause automation
 
 Radiator thermostats can also pause heating from Home Assistant when a selected window sensor, or a Home Assistant group of window sensors, stays open for more than one minute.

--- a/custom_components/danfoss_ally/binary_sensor.py
+++ b/custom_components/danfoss_ally/binary_sensor.py
@@ -170,11 +170,11 @@ class DanfossAllyBinarySensor(DanfossAllyEntity, BinarySensorEntity):
     @property
     def available(self) -> bool:
         """Return whether the binary sensor should be available."""
-        if (
-            self.entity_description.key == "open_window"
-            and self.uses_window_sensor_source()
-        ):
-            return False
+        if self.entity_description.key == "open_window":
+            if not self.native_window_detection_enabled():
+                return False
+            if self.uses_window_sensor_source():
+                return False
 
         return super().available
 

--- a/custom_components/danfoss_ally/climate.py
+++ b/custom_components/danfoss_ally/climate.py
@@ -19,6 +19,7 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_platform
 
 from .const import (
@@ -348,6 +349,11 @@ class DanfossAllyClimate(DanfossAllyEntity, ClimateEntity):
 
     async def async_set_window_state_open(self, **kwargs: Any) -> None:
         """Tell the thermostat whether a window is open."""
+        if not self.native_window_detection_enabled():
+            raise HomeAssistantError(
+                "Window open state can only be set when window open detection is enabled."
+            )
+
         value = "open" if kwargs["window_open"] else "close"
         await self.coordinator.async_send_commands(
             self._device_id,

--- a/custom_components/danfoss_ally/entity.py
+++ b/custom_components/danfoss_ally/entity.py
@@ -92,3 +92,7 @@ class DanfossAllyEntity(CoordinatorEntity[DanfossAllyDataUpdateCoordinator], Ent
     def uses_window_sensor_source(self) -> bool:
         """Return whether the thermostat uses a Home Assistant window sensor source."""
         return self.coordinator.get_window_sensor_entity_id(self._device_id) is not None
+
+    def native_window_detection_enabled(self) -> bool:
+        """Return whether the native thermostat window detection is enabled."""
+        return bool(self.device.get("window_toggle"))

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from homeassistant.components.climate.const import PRESET_HOME
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.danfoss_ally.climate import DanfossAllyClimate
 from custom_components.danfoss_ally.const import PRESET_HOLIDAY, PRESET_PAUSE
@@ -92,6 +93,7 @@ def make_device(**overrides):
         "name": "Living room",
         "model": "Danfoss Ally Thermostat",
         "online": True,
+        "window_toggle": True,
         "mode": "manual",
         "manual_mode_fast": 21.0,
         "at_home_setting": 20.0,
@@ -254,6 +256,33 @@ async def test_set_external_temperature_enables_radiator_covered() -> None:
                 "external_sensor_temperature": 25.0,
             },
         )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_set_window_state_open_requires_window_detection_to_be_enabled() -> None:
+    """Window state writes should fail when native window detection is disabled."""
+    coordinator = FakeCoordinator({"device-1": make_device(window_toggle=False)})
+    entity = DanfossAllyClimate(coordinator, "device-1")
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_window_state_open(window_open=True)
+
+    assert coordinator.command_calls == []
+
+
+@pytest.mark.asyncio
+async def test_set_window_state_open_sends_command_when_window_detection_is_enabled() -> (
+    None
+):
+    """Window state writes should still work when native window detection is enabled."""
+    coordinator = FakeCoordinator({"device-1": make_device(window_toggle=True)})
+    entity = DanfossAllyClimate(coordinator, "device-1")
+
+    await entity.async_set_window_state_open(window_open=True)
+
+    assert coordinator.command_calls == [
+        ("device-1", [("window_state_info", "open")], None)
     ]
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -101,3 +101,24 @@ def test_open_window_binary_sensor_becomes_unavailable_when_window_source_is_con
     entity = DanfossAllyBinarySensor(coordinator, "device-1", description)
 
     assert entity.available is False
+
+
+def test_open_window_binary_sensor_becomes_unavailable_when_window_detection_is_off() -> (
+    None
+):
+    """Native open-window binary sensor should become unavailable when detection is disabled."""
+    coordinator = FakeCoordinator(
+        {
+            "device-1": {
+                "name": "Living room",
+                "model": "Danfoss Ally Thermostat",
+                "online": True,
+                "window_open": True,
+                "window_toggle": False,
+            }
+        }
+    )
+    description = next(item for item in BINARY_SENSORS if item.key == "open_window")
+    entity = DanfossAllyBinarySensor(coordinator, "device-1", description)
+
+    assert entity.available is False


### PR DESCRIPTION
## Summary
This PR makes the native open-window state follow the thermostats own detection switch more strictly.

## Changes
The native `Open window` binary sensor is now only available while `Open window detection` is enabled. The `Danfoss Ally: Set window open state` service now fails explicitly when the detection switch is turned off, so Home Assistant can no longer push a native window-open state while the feature is disabled.

The README now also notes this behavior so it is easier to understand from the UI and service side.

## Test strategy
Automated:
- `ruff format .`
- `ruff check .`
- `pytest tests/test_sensor.py tests/test_climate.py`

## Known limitations
This does not change the separate Home Assistant `Window sensor source` pause automation flow.

## Configuration changes
No configuration changes are required.

## Semver
Proposed and verified with user: `patch`
