### PR TITLE
Distinguish Cool from cool_active in hvac_action

### DIFF
--- a/custom_components/danfoss_ally/climate.py
+++ b/custom_components/danfoss_ally/climate.py
@@ -183,20 +183,30 @@ class DanfossAllyClimate(DanfossAllyEntity, ClimateEntity):
         work_state = self.device_value("work_state")
         valve_opening = self.device_value("valve_opening", "valveOpening")
 
-        # V2.2.0 forbedringer: work_state tjek FØRST (inkl. NoHeat/idle prioritet)
-        if work_state in {"NoHeat", "idle"}:
-            return HVACAction.IDLE
-        if work_state in {"Cool", "cool_active"}:
-            return HVACAction.COOLING
-        if work_state in {"Heat", "heat_active"}:
-            if valve_opening is not None:
-                return (
-                    HVACAction.HEATING if float(valve_opening) > 1 else HVACAction.IDLE
-                )
-            # For Icon devices without valve_opening, fall back to output_status
-            if output_status is not None:
-                return HVACAction.HEATING if output_status else HVACAction.IDLE
-            return HVACAction.HEATING
+        if work_state is not None:
+            state = str(work_state).lower()
+            if state in {"noheat", "idle"}:
+                return HVACAction.IDLE
+
+            direction: HVACAction | None = None
+            if state.startswith("cool"):
+                direction = HVACAction.COOLING
+            elif state.startswith("heat"):
+                direction = HVACAction.HEATING
+
+            if direction is not None:
+                # The `_active` suffix is the device's explicit activity flag,
+                # distinct from the bare `Cool`/`Heat` regulation-mode value.
+                # Don't collapse them back into one set: a bare `Cool`/`Heat`
+                # only means "this is the current regulation mode", not that
+                # the room is actively calling for it.
+                if state.endswith("_active"):
+                    return direction
+                if valve_opening is not None:
+                    return direction if float(valve_opening) > 1 else HVACAction.IDLE
+                if output_status is not None:
+                    return direction if output_status else HVACAction.IDLE
+                return HVACAction.IDLE
 
         # V2.1.0 style: output_status fallback for devices without work_state
         if output_status is not None:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -349,6 +349,82 @@ def test_hvac_action_uses_valve_opening_for_heat_work_state() -> None:
     assert entity.hvac_action.value == "heating"
 
 
+def test_hvac_action_reports_idle_for_cool_work_state_without_active_suffix() -> None:
+    """A bare Cool work_state without the _active suffix is idle, not cooling.
+
+    Observed on a live Icon2 Living Room reading: work_state="Cool",
+    output_status="Inactive", temp_current=21.3 vs a 20.5 setpoint (+0.8 K,
+    below Danfoss's +2 K cooling-engagement threshold), and no flow indicator
+    shown in the Ally app.
+    """
+    coordinator = FakeCoordinator(
+        {
+            "device-1": make_device(
+                output_status=False,
+                work_state="Cool",
+                valve_opening=None,
+            )
+        }
+    )
+    entity = DanfossAllyClimate(coordinator, "device-1")
+
+    assert entity.hvac_action.value == "idle"
+
+
+def test_hvac_action_reports_cooling_for_cool_active_work_state() -> None:
+    """The cool_active work_state is the device's explicit call for cooling.
+
+    Observed on a live Icon2 Bedroom reading: work_state="cool_active",
+    output_status="active", temp_current=21.2 vs a 19.0 setpoint (+2.2 K,
+    above Danfoss's +2 K cooling-engagement threshold), matching the flow
+    indicator shown in the Ally app.
+    """
+    coordinator = FakeCoordinator(
+        {
+            "device-1": make_device(
+                output_status=True,
+                work_state="cool_active",
+                valve_opening=None,
+            )
+        }
+    )
+    entity = DanfossAllyClimate(coordinator, "device-1")
+
+    assert entity.hvac_action.value == "cooling"
+
+
+def test_hvac_action_reports_idle_for_heat_work_state_without_telemetry() -> None:
+    """A bare Heat work_state without valve or actuator telemetry is idle."""
+    coordinator = FakeCoordinator(
+        {
+            "device-1": make_device(
+                output_status=None,
+                work_state="Heat",
+                valve_opening=None,
+            )
+        }
+    )
+    entity = DanfossAllyClimate(coordinator, "device-1")
+
+    assert entity.hvac_action.value == "idle"
+
+
+def test_hvac_action_work_state_comparison_is_case_insensitive() -> None:
+    """work_state casing must not affect the active-suffix comparison."""
+    coordinator = FakeCoordinator(
+        {
+            "device-1": make_device(
+                output_status=None,
+                work_state="Cool_Active",
+                valve_opening=None,
+            )
+        }
+    )
+    entity = DanfossAllyClimate(coordinator, "device-1")
+
+    assert entity.hvac_action.value == "cooling"
+
+
 def test_hvac_action_falls_back_to_output_status_without_work_state() -> None:
     """Devices without work_state should still use output_status as a fallback."""
     coordinator = FakeCoordinator(


### PR DESCRIPTION
Cool/Heat and cool_active/heat_active are distinct work_state enum values, not spelling variants: the _active suffix is the device's explicit activity flag. Collapsing them into one set made Icon2 hvac_action report cooling/heating for every room permanently, including rooms below setpoint or with cooling disabled.

hvac_action now normalises work_state to lowercase, derives direction from the cool*/heat* prefix, and derives activity from the _active suffix first, falling back to valve_opening then output_status.

Tested fix on my HA installation (2026.3). See screenshot. Thermostats now show correct state, matching the Ally app. Before this fix, every thermostat was perpetually on 'Cooling'. Even the thermostat which has cooling disabled. 

<img width="1484" height="889" alt="image" src="https://github.com/user-attachments/assets/484b28f1-9760-4a75-a988-52192a5937dd" />
