### PR TITLE
Convert external sensor readings to Celsius before sending them

### DIFF
--- a/custom_components/danfoss_ally/coordinator.py
+++ b/custom_components/danfoss_ally/coordinator.py
@@ -17,11 +17,13 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    UnitOfTemperature,
 )
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util.unit_conversion import TemperatureConverter
 from pydanfossally import DanfossAlly, exceptions
 
 from .const import (
@@ -1153,13 +1155,24 @@ class DanfossAllyDataUpdateCoordinator(
             and state.attributes.get("current_temperature") is not None
         )
 
+    @staticmethod
+    def _to_celsius(value: float, unit: Any) -> float:
+        """Convert a temperature reading in [unit] to Celsius."""
+        if unit in (UnitOfTemperature.FAHRENHEIT, UnitOfTemperature.KELVIN):
+            return TemperatureConverter.convert(
+                value, unit, UnitOfTemperature.CELSIUS
+            )
+        return value
+
     def _extract_temperature_celsius(self, state: Any) -> float | None:
         """Extract a temperature value from a state object."""
         if state is None:
             return None
 
+        unit = state.attributes.get("unit_of_measurement")
+
         try:
-            return float(state.state)
+            return self._to_celsius(float(state.state), unit)
         except (ValueError, TypeError):
             pass
 
@@ -1168,7 +1181,7 @@ class DanfossAllyDataUpdateCoordinator(
             return None
 
         try:
-            return float(current_temperature)
+            return self._to_celsius(float(current_temperature), unit)
         except (ValueError, TypeError):
             return None
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -573,3 +573,48 @@ async def test_set_window_sensor_entity_updates_runtime_listeners_immediately() 
     )
 
     coordinator.async_update_listeners.assert_called_once()
+
+
+def test_extract_temperature_celsius_converts_fahrenheit() -> None:
+    """A sensor reporting Fahrenheit must be converted before it is sent as Celsius."""
+    state = State(
+        "sensor.living_room_temperature",
+        "70",
+        {"unit_of_measurement": "°F", "device_class": "temperature"},
+    )
+
+    coordinator = object.__new__(DanfossAllyDataUpdateCoordinator)
+
+    result = coordinator._extract_temperature_celsius(state)
+
+    assert result == pytest.approx(21.111, abs=0.01)
+
+
+def test_extract_temperature_celsius_converts_kelvin() -> None:
+    """A sensor reporting Kelvin must be converted before it is sent as Celsius."""
+    state = State(
+        "sensor.living_room_temperature",
+        "294.15",
+        {"unit_of_measurement": "K", "device_class": "temperature"},
+    )
+
+    coordinator = object.__new__(DanfossAllyDataUpdateCoordinator)
+
+    result = coordinator._extract_temperature_celsius(state)
+
+    assert result == pytest.approx(21.0, abs=0.01)
+
+
+def test_extract_temperature_celsius_leaves_celsius_untouched() -> None:
+    """A Celsius sensor must pass through unchanged."""
+    state = State(
+        "sensor.living_room_temperature",
+        "21.5",
+        {"unit_of_measurement": "°C", "device_class": "temperature"},
+    )
+
+    coordinator = object.__new__(DanfossAllyDataUpdateCoordinator)
+
+    result = coordinator._extract_temperature_celsius(state)
+
+    assert result == pytest.approx(21.5, abs=0.01)


### PR DESCRIPTION
## The problem

`_is_temperature_entity` decides which entities are offered as an external temperature source, and it deliberately accepts three units:

```python
if unit in {"°C", "°F", "K"}:
    return True
```

`_extract_temperature_celsius`, immediately below it, reads the value with a bare `float()` and never looks at the unit:

```python
try:
    return float(state.state)
except (ValueError, TypeError):
    pass
```

`_async_send_external_temperature` then writes it out as `ext_measured_rs` in 0.01°C units:

```python
temp_value = int(round(temp_celsius * 100))
```

So picking a Fahrenheit sensor sends the raw number through as Celsius. A room at **70°F reaches the device as 70.00°C**, and a Kelvin sensor at 294.15 K arrives as 294.15°C. Both sit far above any plausible setpoint, so the radiator closes and stays closed for as long as that external sensor is configured and nothing in the log says why, because from the integration's point of view the value was accepted and sent successfully.

## The change

Convert with Home Assistant's own `TemperatureConverter` when the unit is Fahrenheit or Kelvin, and leave every other case exactly as it was, Celsius sensors, and climate entities that expose `current_temperature` without a `unit_of_measurement`, keep their existing behaviour.

## Tests

Three added to `tests/test_coordinator.py`, following the existing `object.__new__(DanfossAllyDataUpdateCoordinator)` style used elsewhere in that file:

- Fahrenheit `"70"` → 21.11°C
- Kelvin `"294.15"` → 21.0°C
- Celsius `"21.5"` → 21.5°C unchanged

Verified both ways on this branch:

```
without the fix:  2 failed, 1 passed     (Fahrenheit and Kelvin fail, Celsius passes)
with the fix:     78 passed              (75 existing + 3 new)
ruff check:       All checks passed!
```

Run with Python 3.14 and the pinned `homeassistant==2026.8.3` from `requirements.txt`.